### PR TITLE
(PAYM-906) Added `docker-context` to `build-docker-images` action

### DIFF
--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -16,6 +16,9 @@ inputs:
   gcloud-service-account:
     description: Google Cloud service account
     required: true
+  docker-context:
+    description: The context folder where the image is built
+    required: true
 runs:
   using: composite
   steps:
@@ -53,7 +56,7 @@ runs:
     - name: Docker Build and Push
       uses: docker/build-push-action@v2
       with:
-        context: ./src
+        context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile-path }}/Dockerfile
         platforms: linux/amd64,linux/arm64
         push: true


### PR DESCRIPTION
Motivation
---
To create Liquibase docker image, we need to specify context folder to `build-docker-images`. This field is currently hard-coded.

Modifications
---
Added `docker-context` input parameter

Results
---
We should be able to build image for any other docker file in a repo