### PR TITLE
(PAYM-1010) Adding always to reports for functional tests

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -45,6 +45,7 @@ runs:
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1
+      if: always()
       with:
         name: Integration Tests
         path: test/tests/bin/results/*.xml


### PR DESCRIPTION
Motivation
---
Functional test reports were not being generated when failure occurs
Modifications
---
Added when: always() to git action
Results
---
Should now always produce report 