### PR TITLE
(PAYM-1033) Update GitHub Action to Publish Latest on Main

### DIFF
--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -54,7 +54,7 @@ runs:
           # version from sem-ver
           ${{ inputs.sem-ver }}
           # push latest if we're pushing main
-          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'PAYM-1037-update-to-use-latest') }}
     
     - name: Docker Build and Push
       uses: docker/build-push-action@v2

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -51,7 +51,10 @@ runs:
       with:
         images: ${{ env.GCR_REGISTRY }}/${{ env.CONTAINER_NAME }}
         tags: |
+          # version from sem-ver
           ${{ inputs.sem-ver }}
+          # push latest if we're pushing main
+          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
     
     - name: Docker Build and Push
       uses: docker/build-push-action@v2

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -54,7 +54,7 @@ runs:
           # version from sem-ver
           ${{ inputs.sem-ver }}
           # push latest if we're pushing main
-          type=raw,value=latest,enable=true
+          type=raw,value=latest,enable={{is_default_branch}}
     
     - name: Docker Build and Push
       uses: docker/build-push-action@v2

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -54,7 +54,7 @@ runs:
           # version from sem-ver
           ${{ inputs.sem-ver }}
           # push latest if we're pushing main
-          type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'PAYM-1037-update-to-use-latest') }}
+          type=raw,value=latest,enable=true
     
     - name: Docker Build and Push
       uses: docker/build-push-action@v2


### PR DESCRIPTION
Motivation
---
 - I want to keep latest up to date on our GCR repositories

Modifications
---
 - Updated the GitHub Action to add a latest tag when on main

Results
---
 - You'll now get a latest tag on main

Example from a PR build
![image](https://user-images.githubusercontent.com/101014394/184982862-b2fd2ec3-e633-4e68-96ec-c2fb12ab96bf.png)
