### PR TITLE
Added an input value for the version of .NET

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -7,13 +7,17 @@ inputs:
   solution-file:
     description: The solution file name with relative path
     required: true
+  dotnet-version:
+    description: The version of .NET for Setup task
+    default: 6.0.x
+    required: false
 runs:
   using: composite
   steps:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: ${{ inputs.dotnet-version }}
 
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
Motivation
---
The new projects' build that have upgraded to .NET break.

Modifications
---
Added an input variable to pass .NET version if needed.

Results
---
This action should work both for existing and projects upgraded to .NET 7