### PR TITLE
(PAYM-1073) Add a parameter for .NET version

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   dotnet-version:
     description: The version of .NET for Setup task
-    default: 6.0.x
+    default: 6.0.*
     required: false
 runs:
   using: composite

--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -7,13 +7,17 @@ inputs:
   solution-file:
     description: The solution file name with relative path
     required: true
+  dotnet-version:
+    description: The version of .NET for Setup task
+    default: 6.0.x
+    required: false
 runs:
   using: composite
   steps:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: ${{ inputs.dotnet-version }}
 
     - uses: actions/cache@v2
       with:

--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -18,7 +18,8 @@ runs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
-
+        include-prerelease: true
+        
     - uses: actions/cache@v2
       with:
         path: ~/.nuget/packages

--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -15,7 +15,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v2
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
 

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -61,7 +61,7 @@ runs:
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile-path }}/Dockerfile
-        platforms: linux/amd64,linux/arm64
+        platforms: linux/amd64
         push: true
         tags: ${{ steps.docker_meta_pr.outputs.tags }}
         build-args: "GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }}"

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -57,7 +57,7 @@ runs:
           type=raw,value=latest,enable={{is_default_branch}}
     
     - name: Docker Build and Push
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         context: ${{ inputs.docker-context }}
         file: ${{ inputs.dockerfile-path }}/Dockerfile


### PR DESCRIPTION
Motivation
---
The upgraded projects to .NET 7 break.

Modifications
---
Added an input variable to pass .NET version if needed.
Temporarily removed support for emulated arm64 images

Results
---
This action should work both for existing and projects upgraded to .NET 7