### PR TITLE
(PAYM-1487) Update Build Action to support passing in assembly version

### DIFF
--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -4,6 +4,9 @@ inputs:
   sem-ver:
     description: Version of the package
     required: true
+  AssemblySemVer:
+    description: Version of the Assembly
+    required: true
   gh-packages-token:
     description: Github packages token
     required: true
@@ -66,4 +69,4 @@ runs:
         tags: ${{ steps.docker_meta_pr.outputs.tags }}
         build-args: |
           GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }}
-          ASSEMBLY_VERSION=${{ inputs.sem-ver }}
+          ASSEMBLY_VERSION=${{ inputs.AssemblySemVer }}

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -64,4 +64,4 @@ runs:
         platforms: linux/amd64
         push: true
         tags: ${{ steps.docker_meta_pr.outputs.tags }}
-        build-args: "GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }}"
+        build-args: "GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }},ASSEMBLY_VERSION=${{inputs.sem-ver}}"

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -64,4 +64,6 @@ runs:
         platforms: linux/amd64
         push: true
         tags: ${{ steps.docker_meta_pr.outputs.tags }}
-        build-args: "GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }},ASSEMBLY_VERSION=${{inputs.sem-ver}}"
+        build-args: |
+          GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }}
+          ASSEMBLY_VERSION=${{ inputs.sem-ver }}

--- a/get-version/action.yml
+++ b/get-version/action.yml
@@ -10,6 +10,9 @@ outputs:
   nuGetVersionV2:
     description: Nuget Version
     value: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
+  AssemblySemVer:
+    description: Assembly Version
+    value: $${{ steps.gitversion.outputs.AssemblySemVer }}
 runs:
   using: composite
   steps:

--- a/get-version/action.yml
+++ b/get-version/action.yml
@@ -12,7 +12,7 @@ outputs:
     value: ${{ steps.gitversion.outputs.nuGetVersionV2 }}
   AssemblySemVer:
     description: Assembly Version
-    value: $${{ steps.gitversion.outputs.AssemblySemVer }}
+    value: ${{ steps.gitversion.outputs.AssemblySemVer }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Motivation
---
 - I want the built containers to specify their version in the built assembly
 - In order to do this, I need to pass in the ASSEMBLY_VERSION
 - This means updating the version stuff to output the assembly version as well as requiring it as input

Modifications
---
 - Updated build args to include ASSEMBLY_VERSION
 - Updated the version to include AssemblySemVer as an output

Results
---
Now, as part of our docker file, we can do something like this
```
ARG ASSEMBLY_VERSION
WORKDIR "/src/Tesouro.Payments.Service.CardProcessing"
RUN dotnet build "Tesouro.Payments.Service.CardProcessing.csproj" -c Release -o /app/build /p:AssemblyVersion=${ASSEMBLY_VERSION}
```