### PR TITLE
ignore failure to add nuget source.

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -31,7 +31,7 @@ runs:
       working-directory: ./src
       shell: bash
       run: >-
-        dotnet nuget add source --username USERNAME --password ${{ inputs.gh-packages-token }} --store-password-in-clear-text --name github https://nuget.pkg.github.com/tesourohq/index.json
+        dotnet nuget add source --username USERNAME --password ${{ inputs.gh-packages-token }} --store-password-in-clear-text --name github https://nuget.pkg.github.com/tesourohq/index.json || true
         && dotnet restore ${{ inputs.solution-file }}
 
     - name: Build


### PR DESCRIPTION
Motivation
I want the action to continue even if there is a failure on the attempt to a nuget source.

Modifications
Added `|| true` to the end of the bash command.

Results
It was updated.
