### PR TITLE
(PAYM-1491) - Add a ci armory deploy action

### DIFF
--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -1,0 +1,59 @@
+name: Armory Deploy 
+description: Deploy using Armory CDaaS 
+outputs:
+  ArmoryURL:
+    description: URL for Armory UI, to track the deployment. 
+    value: ${{ steps.armory-deploy.outputs.deployment-link }}
+inputs:
+  armory-client-id:
+    description: Client ID, configured in the Armory account being used.
+    required: true
+  armory-client-secret:
+    description: Client Secret, corresponding to the Client ID.
+    required: true
+  armory-yaml-path:
+    description: Path to the armory-deployment.yaml file.
+    required: true
+  prod-manifest-path:
+    description: Location where Kustomize should output the prod manifests. This path is used in the armory-deployment.yaml.
+    required: true
+  stage-manifest-path:
+    description: (Optional) Location where Kustomize should output the stage manifests. This path is used in the armory-deployment.yaml. Step is skipped if not provided.
+    required: false
+  major-minor-patch:
+    description: SemVer, with nothing other than 'major.minor.patch'.
+runs:
+  using: composite
+  steps:
+    - name: Setup Kustomize
+      shell: bash
+      working-directory: deployment/kustomize/base
+      run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+
+    - name: Update Version Label
+      shell: bash
+      working-directory: deployment/kustomize/base
+      run: kustomize edit set label version:${{ inputs.major-minor-patch }}
+
+    - name: Bake Stage Manifests
+      if: inputs.stage-manifest-path != ''
+      shell: bash
+      working-directory: deployment/kustomize/overlays/stage
+      run: kustomize build . -o ${{ inputs.stage-manifest-path }}
+
+    - name: Bake Prod Manifests
+      shell: bash
+      working-directory: deployment/kustomize/overlays/prod
+      run: kustomize build . -o ${{ inputs.prod-manifest-path }}
+
+      # https://docs.armory.io/cd-as-a-service/setup/gh-action/
+    - name: Deploy
+      id: armory-deploy
+      uses: armory/cli-deploy-action@v1.0.0
+      env:
+        PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-path }}
+        STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-path }}  # Note: The deployment-armory.yaml must conditionally execute the Stage deployment, or disregard it, since it is optional here.
+      with:
+        clientId: ${{ inputs.armory-client-id }}
+        clientSecret: ${{ inputs.armory-client-secret }}
+        path-to-file: ${{ inputs.armory-yaml-path }}

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -68,7 +68,7 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
-    
-    - name: Update Summary with Deployment link
-      shell: bash
-      run: "echo 'Deployment URL: ${{ steps.armory-deploy.outputs.deployment-link }}' >> $GITHUB_STEP_SUMMARY"
+
+    # - name: Update Summary with Deployment link
+    #   shell: bash
+    #   run: "echo ':rocket: Deployment URL: ${{ steps.armory-deploy.outputs.deployment-link }} \n$GITHUB_STEP_SUMMARY' > $GITHUB_STEP_SUMMARY"

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -69,8 +69,6 @@ runs:
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
     
-    - name: Update Summary
-      env:
-        URL: ${{ steps.armory-deploy.outputs.deployment-link }}
+    - name: Update Summary with Deployment link
       shell: bash
-      run: "echo 'Deployment URL: $URL' >> $GITHUB_STEP_SUMMARY"
+      run: "echo 'Deployment URL: ${{ steps.armory-deploy.outputs.deployment-link }}' >> $GITHUB_STEP_SUMMARY"

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -1,9 +1,5 @@
 name: Armory Deploy
 description: Deploy using Armory CDaaS
-outputs:
-  ArmoryURL:
-    description: URL for Armory UI, to track the deployment.
-    value: ${{ steps.armory-deploy.outputs.deployment-link }}
 inputs:
   armory-client-id:
     description: Client ID, configured in the Armory account being used.
@@ -56,3 +52,7 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
+    
+    - name: Update Summary with Deployment link
+      shell: bash
+      run: "echo ':rocket: Deployment URL: ${{ steps.armory-deploy.outputs.deployment-link }}' >> $GITHUB_STEP_SUMMARY"

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -19,6 +19,9 @@ inputs:
   major-minor-patch:
     description: SemVer, with nothing other than 'major.minor.patch'.
     required: true
+  image-name:
+    description: The base name of the image. Not the image repository itself. Example - 'tesouro-service-reporting'
+    required: true
   image-tag:
     description: Tag of the image that should be used in the deployment manifest.
     required: true
@@ -33,7 +36,7 @@ runs:
     - name: Update Version Label
       shell: bash
       working-directory: deployment/kustomize/base
-      run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/tesouro-service-reporting:${{ inputs.image-tag }}
+      run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/${{ inputs.image-name }}:${{ inputs.image-tag }}
 
     - name: Bake Stage Manifests
       if: inputs.stage-kustomize-path != '' # Only run if the path is provided, otherwise assume no stage environment is being used.

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -53,8 +53,9 @@ runs:
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
 
-    - name: Update Summary with Deployment link
-      env:
-        URL: ${{ steps.armory-deploy.outputs.deployment-link }}
-      shell: bash
-      run: echo ${URL} && echo ${{ steps.armory-deploy.outputs.deployment-link }}
+# TODO: I've confirmed with Armory that this doesn't work yet. Going to comment it out and restore it in the future.
+    # - name: Update Summary with Deployment link
+    #   env:
+    #     URL: ${{ steps.armory-deploy.outputs.deployment-link }}
+    #   shell: bash
+    #   run: echo ${URL} >> $GITHUB_STEP_SUMMARY && echo ${{ steps.armory-deploy.outputs.deployment-link }} >> $GITHUB_STEP_SUMMARY

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -43,12 +43,12 @@ runs:
       if: inputs.stage-manifest-path != ''
       shell: bash
       working-directory: deployment/kustomize/overlays/stage
-      run: kustomize build . -o ${{ inputs.stage-manifest-path }}
+      run: kustomize build . -o ${{ inputs.stage-manifest-output-path }}
 
     - name: Bake Prod Manifests
       shell: bash
       working-directory: deployment/kustomize/overlays/prod
-      run: kustomize build . -o ${{ inputs.prod-manifest-path }}
+      run: kustomize build . -o ${{ inputs.prod-manifest-output-path }}
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -56,4 +56,4 @@ runs:
         URL: ${{ steps.armory-deploy.outputs.deployment-link }}
     - name: Update Summary with Deployment link
       shell: bash
-      run: "echo :rocket: Deployment URL: $URL >> $GITHUB_STEP_SUMMARY"
+      run: echo Deployment URL = $URL >> $GITHUB_STEP_SUMMARY

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -48,7 +48,7 @@ runs:
     - name: Bake Prod Manifests
       shell: bash
       working-directory: deployment/kustomize/overlays/prod
-      run: kustomize build . -o ${{ inputs.prod-manifest-output-path }}
+      run: pwd && ls -la && kustomize build . -o ${{ inputs.prod-manifest-output-path }}
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -52,7 +52,7 @@ runs:
       uses: armory/cli-deploy-action@v1.0.0
       env:
         PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-path }}
-        STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-path }}  # Note: The deployment-armory.yaml must conditionally execute the Stage deployment, or disregard it, since it is optional here.
+        STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-path }}  # Note: The armory-deployment.yaml can safely disregard this env var, if not using it as part of the deployment strategy.
       with:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -58,7 +58,6 @@ runs:
     - name: Deploy
       id: armory-deploy
       uses: armory/cli-deploy-action@v1.0.0
-      if: github.ref == 'refs/heads/main' # ONLY deploy on merge to main.
       env:
         PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-output-path }}
         STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-output-path }}

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -50,6 +50,7 @@ runs:
     - name: Deploy
       id: armory-deploy
       uses: armory/cli-deploy-action@v1.0.0
+      if: github.ref == 'refs/heads/main'  # ONLY deploy on merge to main.
       env:
         PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-path }}
         STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-path }}  # Note: The armory-deployment.yaml can safely disregard this env var, if not using it as part of the deployment strategy.

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -1,8 +1,8 @@
-name: Armory Deploy 
-description: Deploy using Armory CDaaS 
+name: Armory Deploy
+description: Deploy using Armory CDaaS
 outputs:
   ArmoryURL:
-    description: URL for Armory UI, to track the deployment. 
+    description: URL for Armory UI, to track the deployment.
     value: ${{ steps.armory-deploy.outputs.deployment-link }}
 inputs:
   armory-client-id:
@@ -46,21 +46,19 @@ runs:
       run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/tesouro-service-reporting:${{ inputs.image-tag }}
 
     - name: Bake Stage Manifests
-      if: inputs.stage-kustomize-path != '' && inputs.stage-manifest-output-path != ''  # Only run if the paths are provided, otherwise assume no stage environment is being used.
+      if: inputs.stage-kustomize-path != '' && inputs.stage-manifest-output-path != '' # Only run if the paths are provided, otherwise assume no stage environment is being used.
       shell: bash
-      # working-directory: deployment/kustomize/overlays/stage
       run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-manifest-output-path }}
 
     - name: Bake Prod Manifests
       shell: bash
-      # working-directory: deployment/kustomize/overlays/prod
       run: kustomize build ${{ inputs.prod-kustomize-path }} -o ${{ inputs.prod-manifest-output-path }}
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy
       id: armory-deploy
       uses: armory/cli-deploy-action@v1.0.0
-      if: github.ref == 'refs/heads/main'  # ONLY deploy on merge to main.
+      if: github.ref == 'refs/heads/main' # ONLY deploy on merge to main.
       env:
         PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-output-path }}
         STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-output-path }}
@@ -68,7 +66,3 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
-
-    # - name: Update Summary with Deployment link
-    #   shell: bash
-    #   run: "echo ':rocket: Deployment URL: ${{ steps.armory-deploy.outputs.deployment-link }} \n$GITHUB_STEP_SUMMARY' > $GITHUB_STEP_SUMMARY"

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -56,4 +56,4 @@ runs:
         URL: ${{ steps.armory-deploy.outputs.deployment-link }}
     - name: Update Summary with Deployment link
       shell: bash
-      run: echo ${{ steps.armory-deploy.outputs.deployment-link }} >> $GITHUB_STEP_SUMMARY
+      run: echo ${URL} >> $GITHUB_STEP_SUMMARY

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -52,8 +52,9 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
+
+    - name: Update Summary with Deployment link
       env:
         URL: ${{ steps.armory-deploy.outputs.deployment-link }}
-    - name: Update Summary with Deployment link
       shell: bash
-      run: echo ${URL} >> $GITHUB_STEP_SUMMARY
+      run: echo ${URL} && echo ${{ steps.armory-deploy.outputs.deployment-link }}

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -14,9 +14,15 @@ inputs:
   armory-yaml-path:
     description: Path to the armory-deployment.yaml file.
     required: true
+  prod-kustomize-path:
+    description: Path from the project root to the production kustomize overlay.
+    required: true
   prod-manifest-output-path:
     description: Location where Kustomize should output the prod manifests. This path is used in the armory-deployment.yaml.
     required: true
+  stage-kustomize-path:
+    description: (Optional) Path from the project root to the stage kustomize overlay.
+    required: false
   stage-manifest-output-path:
     description: (Optional) Location where Kustomize should output the stage manifests. This path is used in the armory-deployment.yaml. Step is skipped if not provided.
     required: false
@@ -40,15 +46,15 @@ runs:
       run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/tesouro-service-reporting:${{ inputs.image-tag }}
 
     - name: Bake Stage Manifests
-      if: inputs.stage-manifest-path != ''
+      if: inputs.stage-kustomize-path != '' && inputs.stage-manifest-output-path != ''  # Only run if the paths are provided, otherwise assume no stage environment is being used.
       shell: bash
-      working-directory: deployment/kustomize/overlays/stage
-      run: kustomize build . -o ${{ inputs.stage-manifest-output-path }}
+      # working-directory: deployment/kustomize/overlays/stage
+      run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-manifest-output-path }}
 
     - name: Bake Prod Manifests
       shell: bash
-      working-directory: deployment/kustomize/overlays/prod
-      run: pwd && ls -la && kustomize build . -o ${{ inputs.prod-manifest-output-path }}
+      # working-directory: deployment/kustomize/overlays/prod
+      run: kustomize build ${{ inputs.prod-kustomize-path }} -o ${{ inputs.prod-manifest-output-path }}
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy
@@ -56,9 +62,15 @@ runs:
       uses: armory/cli-deploy-action@v1.0.0
       if: github.ref == 'refs/heads/main'  # ONLY deploy on merge to main.
       env:
-        PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-path }}
-        STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-path }}  # Note: The armory-deployment.yaml can safely disregard this env var, if not using it as part of the deployment strategy.
+        PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-output-path }}
+        STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-output-path }}
       with:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
+    
+    - name: Update Summary
+      env:
+        URL: ${{ steps.armory-deploy.outputs.deployment-link }}
+      shell: bash
+      run: "echo 'Deployment URL: $URL' >> $GITHUB_STEP_SUMMARY"

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -23,6 +23,9 @@ inputs:
   major-minor-patch:
     description: SemVer, with nothing other than 'major.minor.patch'.
     required: true
+  image-tag:
+    description: Tag of the image that should be used in the deployment manifest.
+    required: true
 runs:
   using: composite
   steps:
@@ -34,7 +37,7 @@ runs:
     - name: Update Version Label
       shell: bash
       working-directory: deployment/kustomize/base
-      run: kustomize edit set label version:${{ inputs.major-minor-patch }}
+      run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/tesouro-service-reporting:${{ inputs.image-tag }}
 
     - name: Bake Stage Manifests
       if: inputs.stage-manifest-path != ''

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -38,7 +38,7 @@ runs:
     - name: Bake Stage Manifests
       if: inputs.stage-kustomize-path != '' # Only run if the path is provided, otherwise assume no stage environment is being used.
       shell: bash
-      run: kustomize build ${{ inputs.stage-kustomize-path }} -o stage-manifests.yaml  # As with prod below, this requires the armory-deployment.yaml to look in the project root for the manifest, at this name.
+      run: kustomize build ${{ inputs.stage-kustomize-path }} -o stage-manifests.yaml # As with prod below, this requires the armory-deployment.yaml to look in the project root for the manifest, at this name.
 
     - name: Bake Prod Manifests
       shell: bash
@@ -52,10 +52,9 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
-
 # TODO: I've confirmed with Armory that this doesn't work yet. Going to comment it out and restore it in the future.
-    # - name: Update Summary with Deployment link
-    #   env:
-    #     URL: ${{ steps.armory-deploy.outputs.deployment-link }}
-    #   shell: bash
-    #   run: echo ${URL} >> $GITHUB_STEP_SUMMARY && echo ${{ steps.armory-deploy.outputs.deployment-link }} >> $GITHUB_STEP_SUMMARY
+# - name: Update Summary with Deployment link
+#   env:
+#     URL: ${{ steps.armory-deploy.outputs.deployment-link }}
+#   shell: bash
+#   run: echo ${URL} >> $GITHUB_STEP_SUMMARY && echo ${{ steps.armory-deploy.outputs.deployment-link }} >> $GITHUB_STEP_SUMMARY

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -56,4 +56,4 @@ runs:
         URL: ${{ steps.armory-deploy.outputs.deployment-link }}
     - name: Update Summary with Deployment link
       shell: bash
-      run: echo Deployment URL = $URL >> $GITHUB_STEP_SUMMARY
+      run: echo ${{ steps.armory-deploy.outputs.deployment-link }} >> $GITHUB_STEP_SUMMARY

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -52,7 +52,8 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
-    
+      env:
+        URL: ${{ steps.armory-deploy.outputs.deployment-link }}
     - name: Update Summary with Deployment link
       shell: bash
-      run: "echo ':rocket: Deployment URL: ${{ steps.armory-deploy.outputs.deployment-link }}' >> $GITHUB_STEP_SUMMARY"
+      run: "echo :rocket: Deployment URL: $URL >> $GITHUB_STEP_SUMMARY"

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -17,14 +17,8 @@ inputs:
   prod-kustomize-path:
     description: Path from the project root to the production kustomize overlay.
     required: true
-  prod-manifest-output-path:
-    description: Location where Kustomize should output the prod manifests. This path is used in the armory-deployment.yaml.
-    required: true
   stage-kustomize-path:
     description: (Optional) Path from the project root to the stage kustomize overlay.
-    required: false
-  stage-manifest-output-path:
-    description: (Optional) Location where Kustomize should output the stage manifests. This path is used in the armory-deployment.yaml. Step is skipped if not provided.
     required: false
   major-minor-patch:
     description: SemVer, with nothing other than 'major.minor.patch'.
@@ -46,21 +40,18 @@ runs:
       run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/tesouro-service-reporting:${{ inputs.image-tag }}
 
     - name: Bake Stage Manifests
-      if: inputs.stage-kustomize-path != '' && inputs.stage-manifest-output-path != '' # Only run if the paths are provided, otherwise assume no stage environment is being used.
+      if: inputs.stage-kustomize-path != '' # Only run if the path is provided, otherwise assume no stage environment is being used.
       shell: bash
-      run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-manifest-output-path }}
+      run: kustomize build ${{ inputs.stage-kustomize-path }} -o stage-manifests.yaml  # As with prod below, this requires the armory-deployment.yaml to look in the project root for the manifest, at this name.
 
     - name: Bake Prod Manifests
       shell: bash
-      run: kustomize build ${{ inputs.prod-kustomize-path }} -o ${{ inputs.prod-manifest-output-path }}
+      run: kustomize build ${{ inputs.prod-kustomize-path }} -o prod-manifests.yaml
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy
       id: armory-deploy
       uses: armory/cli-deploy-action@v1.0.0
-      env:
-        PROD_MANIFEST_PATH: ${{ inputs.prod-manifest-output-path }}
-        STAGE_MANIFEST_PATH: ${{ inputs.stage-manifest-output-path }}
       with:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -14,14 +14,15 @@ inputs:
   armory-yaml-path:
     description: Path to the armory-deployment.yaml file.
     required: true
-  prod-manifest-path:
+  prod-manifest-output-path:
     description: Location where Kustomize should output the prod manifests. This path is used in the armory-deployment.yaml.
     required: true
-  stage-manifest-path:
+  stage-manifest-output-path:
     description: (Optional) Location where Kustomize should output the stage manifests. This path is used in the armory-deployment.yaml. Step is skipped if not provided.
     required: false
   major-minor-patch:
     description: SemVer, with nothing other than 'major.minor.patch'.
+    required: true
 runs:
   using: composite
   steps:

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -23,7 +23,8 @@ targets:
             # The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.
               duration: 0
               unit: SECONDS
-        - untilApproved: true  # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set. 
+        # - pause:
+        #     untilApproved: false # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set.
       afterDeployment: []
       # Defines the deployment targets that must reach a successful state (defined as status == SUCCEEDED) before this deployment can start. Deployments with the same dependsOn criteria will execute in parallel.
       dependsOn: [stage]

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -1,0 +1,48 @@
+version: v1
+kind: kubernetes
+application: reporting # The name of the application to deploy. This is semantic: It matters for controlling concurrent deployments. Also used for pricing.
+deploymentConfig:
+  timeout: # Optional. Sets a timeout for rolling back deployments that do not reach a READY state. Applies to all deployments in this file. Must be equal to or greater than 1 minute
+    duration: 900
+    unit: SECONDS
+targets:
+  stage:
+    account: payments-cloud-stage
+    namespace: service
+    strategy: full-deployment
+  prod:
+    account: payments-cloud-us-east-1 # The name that you assigned to the deployment target cluster when you installed the RNA.
+    namespace: service # Set the namespace that the app gets deployed to. Overrides the namespaces that are in your manifests. For now, needs to target single space, as the fallback to default is forthcoming.
+    strategy: canary-25 # A named strategy from the strategies block. This example uses the name canary-25.
+    constraints:
+      beforeDeployment:
+        - pause: # The step type
+            # The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.
+            #   duration: 1
+            #   unit: SECONDS
+            untilApproved: true  # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set. 
+      afterDeployment: []
+      # Defines the deployment targets that must reach a successful state (defined as status == SUCCEEDED) before this deployment can start. Deployments with the same dependsOn criteria will execute in parallel.
+      dependsOn: [stage]
+manifests: # The list of manifest sources. Can be a directory or file. 
+  - path: $STAGE_MANIFEST_PATH
+    targets:
+      - stage
+  - path: $PROD_MANIFEST_PATH # Reads all yaml|yml files in the directory and deploy all the manifests found.
+    targets:
+      - prod
+strategies: # A map of named strategies that can be assigned to deployment targets in the targets block.
+  full-deploy:
+    canary:
+      steps:
+        - setWeight:
+            weight: 100
+  canary-25: # Name for a strategy that you use to refer to it. Used in the target block. This example uses canary-25 as the name.
+    canary: # The deployment strategy type. Can be "canary" or "blueGreen"
+      # The steps for your deployment strategy.
+      steps:
+        - setWeight:
+            # The percentage of pods that should be running the canary version for this step. Set it to an integer between 0 and 100, inclusive.
+            weight: 25
+        - pause:
+            untilApproved: true

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -1,3 +1,6 @@
+# This example deployment configuration waits for the deploy to stage to fully succeed, then pauses for manual approval before deploying to prod. The deploy to prod uses the pod-ratio method
+# to come as close to 25% as possible, then pauses for manual confirmation before progressing to 100% and concluding.
+
 version: v1
 kind: kubernetes
 application: reporting # The name of the application to deploy. This is semantic: It matters for controlling concurrent deployments. Also used for pricing.
@@ -18,9 +21,9 @@ targets:
       beforeDeployment:
         - pause: # The step type
             # The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.
-            #   duration: 1
-            #   unit: SECONDS
-            untilApproved: true  # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set. 
+              duration: 0
+              unit: SECONDS
+        - untilApproved: true  # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set. 
       afterDeployment: []
       # Defines the deployment targets that must reach a successful state (defined as status == SUCCEEDED) before this deployment can start. Deployments with the same dependsOn criteria will execute in parallel.
       dependsOn: [stage]

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -9,34 +9,34 @@ deploymentConfig:
     duration: 900
     unit: SECONDS
 targets:
-  stage:
-    account: payments-cloud-stage
-    namespace: service
-    strategy: full-deployment
+  # stage:
+  #   account: payments-cloud-stage
+  #   namespace: service
+  #   strategy: full-deployment
   prod:
     account: payments-cloud-us-east-1 # The name that you assigned to the deployment target cluster when you installed the RNA.
     namespace: service # Set the namespace that the app gets deployed to. Overrides the namespaces that are in your manifests. For now, needs to target single space, as the fallback to default is forthcoming.
-    strategy: canary-25 # A named strategy from the strategies block. This example uses the name canary-25.
+    strategy: full-deployment # A named strategy from the strategies block. This example uses the name canary-25.
     constraints:
-      beforeDeployment:
-        - pause: # The step type
-            # The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.
-            duration: 0
-            unit: SECONDS
+      beforeDeployment: []
+        # - pause: # The step type
+        #     # The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.
+        #     duration: 0
+        #     unit: SECONDS
         # - pause:
         #     untilApproved: false # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set.
-      afterDeployment: [] # TODO: Either here or in beforeDeployment, implement webhooks for external dependencies/integrations: https://docs.armory.io/cd-as-a-service/tasks/webhook-approval/
+      afterDeployment: []
       # Defines the deployment targets that must reach a successful state (defined as status == SUCCEEDED) before this deployment can start. Deployments with the same dependsOn criteria will execute in parallel.
-      dependsOn: [stage]
+      dependsOn: [] # TODO: Add stage here when it is ready.
 manifests: # The list of manifest sources. Can be a directory or file.
-  - path: $STAGE_MANIFEST_PATH
-    targets:
-      - stage
-  - path: $PROD_MANIFEST_PATH # Reads all yaml|yml files in the directory and deploy all the manifests found. Starts at project root (or working dir if set)
+  # - path: ./stage-manifests.yaml
+  #   targets:
+  #     - stage
+  - path: ./prod-manifests.yaml # Reads all yaml|yml files in the directory and deploy all the manifests found.
     targets:
       - prod
 strategies: # A map of named strategies that can be assigned to deployment targets in the targets block.
-  full-deploy:
+  full-deployment:
     canary:
       steps:
         - setWeight:
@@ -48,5 +48,5 @@ strategies: # A map of named strategies that can be assigned to deployment targe
         - setWeight:
             # The percentage of pods that should be running the canary version for this step. Set it to an integer between 0 and 100, inclusive.
             weight: 25
-        - pause:
-            untilApproved: true
+        # - pause:
+        #     untilApproved: true  # TODO: This stategy should call the integration tests, wait for success/fail, then proceed/rollback based on that. We won't pause here for manual approval, ever.

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -25,7 +25,7 @@ targets:
               unit: SECONDS
         # - pause:
         #     untilApproved: false # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set.
-      afterDeployment: []
+      afterDeployment: [] # TODO: Either here or in beforeDeployment, implement webhooks for external dependencies/integrations: https://docs.armory.io/cd-as-a-service/tasks/webhook-approval/
       # Defines the deployment targets that must reach a successful state (defined as status == SUCCEEDED) before this deployment can start. Deployments with the same dependsOn criteria will execute in parallel.
       dependsOn: [stage]
 manifests: # The list of manifest sources. Can be a directory or file. 

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -21,14 +21,14 @@ targets:
       beforeDeployment:
         - pause: # The step type
             # The duration of the pause before the deployment continues. If duration is not zero, set untilApproved to false.
-              duration: 0
-              unit: SECONDS
+            duration: 0
+            unit: SECONDS
         # - pause:
         #     untilApproved: false # If set to true, the deployment waits until a manual approval to continue. Only set this to true if duration and unit are not set.
       afterDeployment: [] # TODO: Either here or in beforeDeployment, implement webhooks for external dependencies/integrations: https://docs.armory.io/cd-as-a-service/tasks/webhook-approval/
       # Defines the deployment targets that must reach a successful state (defined as status == SUCCEEDED) before this deployment can start. Deployments with the same dependsOn criteria will execute in parallel.
       dependsOn: [stage]
-manifests: # The list of manifest sources. Can be a directory or file. 
+manifests: # The list of manifest sources. Can be a directory or file.
   - path: $STAGE_MANIFEST_PATH
     targets:
       - stage

--- a/armory-deploy/example-armory-deployment.yaml
+++ b/armory-deploy/example-armory-deployment.yaml
@@ -31,7 +31,7 @@ manifests: # The list of manifest sources. Can be a directory or file.
   - path: $STAGE_MANIFEST_PATH
     targets:
       - stage
-  - path: $PROD_MANIFEST_PATH # Reads all yaml|yml files in the directory and deploy all the manifests found.
+  - path: $PROD_MANIFEST_PATH # Reads all yaml|yml files in the directory and deploy all the manifests found. Starts at project root (or working dir if set)
     targets:
       - prod
 strategies: # A map of named strategies that can be assigned to deployment targets in the targets block.

--- a/armory-deploy/example-job.yaml
+++ b/armory-deploy/example-job.yaml
@@ -1,0 +1,24 @@
+# This is meant as an example of how the armory-workflow would be used as a job in a workflow.
+
+  ci-armory-deploy:
+    name: Deploy with Armory
+    # if: github.ref == 'refs/heads/main'  # Only on main.
+    runs-on: ubuntu-latest
+    needs: [ci-get-version, ci-build-docker-images]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Bake and Deploy
+        id: bake-and-deploy
+        uses: tesourohq/Tesouro-Github-Actions/armory-deploy@main
+        with:
+          armory-client-id: ${{ secrets.ARMORY_CLIENT_ID }}  # Provided as an org-level Secret
+          armory-client-secret: ${{ secrets.ARMORY_CLIENT_SECRET }}  # Provided as an org-level Secret
+          armory-yaml-path: /deployment/armory/armory-deployment.yaml  # The path from the project root
+          prod-kustomize-path: ./deployment/kustomize/overlays/prod  # The path from the project root
+          major-minor-patch: 1.1.11 # Pulled from the get-version action, it could look like this: ${{ needs.ci-get-version.outputs.MajorMinorPatch }}
+          image-name: tesouro-service-reporting  # The base name of the image, not the repo or tag.
+          image-tag: 1.1.11 # Pulled from the get-version action, it could look like this: ${{ needs.ci-get-version.outputs.MajorMinorPatch }}  # The tag for the image.

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -22,6 +22,13 @@ inputs:
   docker-context:
     description: The context folder where the image is built
     required: true
+outputs:
+  SemVer:
+    description: Semantic Version
+    value: ${{ steps.gitversion.outputs.SemVer }}
+  PushedImage:
+    description: Image name:tag that was pushed to GCR.
+    value: "gcr.io/tesouro-cloud/${{ inputs.image-name }}:${{ inputs.sem-ver }}"
 runs:
   using: composite
   steps:

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -25,10 +25,6 @@ inputs:
   platform:
     description: The platform to target for the build
     default: linux/amd64
-outputs:
-  SemVer:
-    description: Semantic Version
-    value: ${{ steps.gitversion.outputs.SemVer }}
 runs:
   using: composite
   steps:

--- a/build-docker-images/action.yml
+++ b/build-docker-images/action.yml
@@ -26,9 +26,6 @@ outputs:
   SemVer:
     description: Semantic Version
     value: ${{ steps.gitversion.outputs.SemVer }}
-  PushedImage:
-    description: Image name:tag that was pushed to GCR.
-    value: "gcr.io/tesouro-cloud/${{ inputs.image-name }}:${{ inputs.sem-ver }}"
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Motivation
I want to add a common action for using Armory CDaaS, that will bake manifests and deploy using Armory.

Modifications
I added the action.

NOTE: As a part of this merge I am going to make a new release under "v8"

