### PR TITLE
(PAYM-1809) Upgrade to Automatically Prune After Functional Test

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -57,7 +57,7 @@ runs:
       if: always()
       working-directory: ./test
       shell: bash
-      run: docker-compose -f docker-compose.ci.yml -p test_job_test_1 down --remove-orphans --rmi --volumes
+      run: docker-compose -f docker-compose.ci.yml -p test_job_test_1 down --remove-orphans --rmi all --volumes
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -57,7 +57,7 @@ runs:
       if: always()
       working-directory: ./test
       shell: bash
-      run: docker-compose -f docker-compose.ci.yml -p test_job_test_1 down --remove-orphans
+      run: docker-compose -f docker-compose.ci.yml -p test_job_test_1 down --remove-orphans --rmi --volumes
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1


### PR DESCRIPTION
Motivation
---
 - We discovered that about half the runner space was being used by tons of images and volumes remaining
 - This change aims to automatically prune images & volumes after the functional test

Modifications
---
 - Updated the functional test dispose to remove rmi and volume

Results
---
 - Should use MUCH less space over time