### PR TITLE
(PAYM-1795) Armory-deploy inputs

### DIFF
--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -13,9 +13,17 @@ inputs:
   prod-kustomize-path:
     description: Path from the project root to the production kustomize overlay.
     required: true
+  prod-kustomize-output-path:
+    description: Path to the baked kustomize yaml file
+    required: false
+    default: prod-manifests.yaml
   stage-kustomize-path:
     description: (Optional) Path from the project root to the stage kustomize overlay.
     required: false
+  stage-kustomize-output-path:
+    description: Path to the baked kustomize yaml file
+    required: false
+    default: stage-manifests.yaml 
   major-minor-patch:
     description: SemVer, with nothing other than 'major.minor.patch'.
     required: true
@@ -25,27 +33,31 @@ inputs:
   image-tag:
     description: Tag of the image that should be used in the deployment manifest.
     required: true
+  working-directory:
+    description: Working directory for the kustomize edit steps
+    required: false
+    default: deployment/kustomize/base
 runs:
   using: composite
   steps:
     - name: Setup Kustomize
       shell: bash
-      working-directory: deployment/kustomize/base
+      working-directory: ${{ inputs.working-directory }}
       run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 
     - name: Update Version Label
       shell: bash
-      working-directory: deployment/kustomize/base
+      working-directory: ${{ inputs.working-directory }}
       run: kustomize edit set label version:${{ inputs.major-minor-patch }} && kustomize edit set image gcr.io/tesouro-cloud/${{ inputs.image-name }}:${{ inputs.image-tag }}
 
     - name: Bake Stage Manifests
       if: inputs.stage-kustomize-path != '' # Only run if the path is provided, otherwise assume no stage environment is being used.
       shell: bash
-      run: kustomize build ${{ inputs.stage-kustomize-path }} -o stage-manifests.yaml # As with prod below, this requires the armory-deployment.yaml to look in the project root for the manifest, at this name.
+      run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-kustomize-output-path }} # As with prod below, this requires the armory-deployment.yaml to look in the project root for the manifest, at this name.
 
     - name: Bake Prod Manifests
       shell: bash
-      run: kustomize build ${{ inputs.prod-kustomize-path }} -o prod-manifests.yaml
+      run: kustomize build ${{ inputs.prod-kustomize-path }} -o ${{ inputs.prod-kustomize-output-path }}
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy


### PR DESCRIPTION
Motivation
---
We need to add some non-mandatory inputs to the Armory deploy action in order to make it more flexible (in particular, for Frontend deployments)

Modifications
---
- armory action inputs

Results
---
- for builds already using the action, nothing should change
