### PR TITLE
(PAYM-2045) Set `include-prerelease` flag to false

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/setup-dotnet@v2
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
-        include-prerelease: true
+        include-prerelease: false
         
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
Motivation
---
With .NET 7.0 official release, we don't need prerelease SDK builds

Modifications
---
* Set `include-prerelease` flag to false

Results
---
Builds should be only using official release versions