### PR TITLE
(PAYM-2102) Update Functional Test Runner to use variant compose labels

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -29,9 +29,8 @@ runs:
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Clean up existing results
-      working-directory: test/tests/bin/results
       shell: bash
-      run: rm -f swagger.json junit.xml
+      run: rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/junit.xml
 
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -28,6 +28,11 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
+    - name: Clean up existing results
+      working-directory: ./test/tests/bin/results
+      shell: bash
+      run: rm -f swagger.json junit.xml
+
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -29,7 +29,7 @@ runs:
         password: ${{ steps.auth.outputs.access_token }}
 
     - name: Clean up existing results
-      working-directory: ./test/tests/bin/results
+      working-directory: test/tests/bin/results
       shell: bash
       run: rm -f swagger.json junit.xml
 

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -28,10 +28,6 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
-    - name: Clean up existing results
-      shell: bash
-      run: rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/junit.xml
-
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)
@@ -43,12 +39,12 @@ runs:
       run: |
         # Build test container and associated services (and run tests)
         export CLOUDSDK_PYTHON=python2
-        docker-compose -f docker-compose.ci.yml -p test_job_test_1 up --build --force-recreate -d
+        docker-compose -f docker-compose.ci.yml -p job_${{ github.job }}_{{ github.run_number}} up --build --force-recreate -d
 
     # Here, we ask docker to wait until the Jest test container is done running
     - name: Wait on Integration tests
       shell: bash
-      run: docker wait test_job_test_1_test_1
+      run: docker wait job_${{ github.job }}_{{ github.run_number }}_test_1
 
     - name: Archive swagger file
       uses: actions/upload-artifact@v3
@@ -61,7 +57,7 @@ runs:
       if: always()
       working-directory: ./test
       shell: bash
-      run: docker-compose -f docker-compose.ci.yml -p test_job_test_1 down --remove-orphans --rmi all --volumes
+      run: docker-compose -f docker-compose.ci.yml -p job_${{ github.job }}_{{ github.run_number }} down --remove-orphans --rmi all --volumes
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1


### PR DESCRIPTION
Motivation
---
 - So, first, I was chasing this whole thing with trying to nuke junit & swagger and then I realized.... this is all because I keep using the same compose name. I had erroneously thought this would help with rebuilding and saving time, but it really does nothing in that regard and only helps with keeping volumes/etc. around.
 - So, now, I just want to have a new label for each workflowid/runid

Modifications
---
 - Updated our functional tests to use a new workflowid/runid based label

Results
---
 - No more volume matches shenanigans for the "_test_1" container :-) 