### PR TITLE
Make the pacts image location available to the compose file environment

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -7,6 +7,9 @@ inputs:
   image-name:
     description: Base image name to store in GCR
     required: true
+  pacts-image-name:
+    description: Image holding the pacts for this test run
+    required: false
   gcloud-service-account:
     description: Google Cloud service account
     required: true
@@ -35,6 +38,7 @@ runs:
       working-directory: ./test
       env:
         UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
+        UNDERTEST_PACTS_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.pacts-image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
       shell: bash
       run: |
         # Build test container and associated services (and run tests)


### PR DESCRIPTION
Motivation
---
Allow the functional test phase of the start the correct pact generator image.  Merging this is required before merging https://github.com/tesourohq/Tesouro.Payments.Service.PaymentProcessing/pull/263

Modifications
---
* Altered the functional test action to accept a new optional parameter `pacts-image-name` that if supplied will be made available in the environment so that the functional test job in the payment processing workflow can start the correct docker container that contains the pacts for this commit.

Results
---
When running the compose-up for the functional tests:
```
Pulling pact-generator (gcr.io/tesouro-cloud/tesouro-service-payment-processing-pacts-ci:1.0.218-pr-0263.10)...
1.0.218-pr-0263.10: Pulling from tesouro-cloud/tesouro-service-payment-processing-pacts-ci
Digest: sha256:1886d8e6ad398653c8372bf464e7484a202fc7d09df331ab37855d23907d8c06
Status: Downloaded newer image for gcr.io/tesouro-cloud/tesouro-service-payment-processing-pacts-ci:1.0.218-pr-0263.10
```