### PR TITLE
(PAYM-2133) update git hub actions to use correct container name when-…

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -48,7 +48,7 @@ runs:
     # Here, we ask docker to wait until the Jest test container is done running
     - name: Wait on Integration tests
       shell: bash
-      run: docker wait test_job_test_1_test_1
+      run: docker wait test_job_test_1-test-1
 
     - name: Archive swagger file
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
…running-functional-test

Fixed potential typo with docker wait container name

Motivation
It looks like GitHub actions is trying to run docker wait test_job_test_1_test_1 but the container name is test_job_test_1-test-1

Modifications
updated container name

Results
functional tests should run again
