### PR TITLE
(PAYM-2138) Pre & Post Nuking of test/tests/bin/results

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Clean up existing results
       shell: bash
-      run: sudo rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/*.xml
+      run: sudo rm -rf ./test/tests/bin
 
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
@@ -77,4 +77,4 @@ runs:
 
     - name: Clean up results
       shell: bash
-      run: sudo rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/*.xml
+      run: sudo rm -rf ./test/tests/bin

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -28,6 +28,10 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
+    - name: Clean up existing results
+      shell: bash
+      run: rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/*.xml
+
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -28,6 +28,10 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
+    - name: Clean up existing results
+      shell: bash
+      run: rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/junit.xml
+
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)
@@ -39,12 +43,12 @@ runs:
       run: |
         # Build test container and associated services (and run tests)
         export CLOUDSDK_PYTHON=python2
-        docker-compose -f docker-compose.ci.yml -p test_job_test_1 up --build --force-recreate -d
+        docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} up --build --force-recreate -d
 
     # Here, we ask docker to wait until the Jest test container is done running
     - name: Wait on Integration tests
       shell: bash
-      run: docker wait test_job_test_1_test_1
+      run: docker wait test_${{ github.job }}_test_1
 
     - name: Archive swagger file
       uses: actions/upload-artifact@v3
@@ -57,7 +61,7 @@ runs:
       if: always()
       working-directory: ./test
       shell: bash
-      run: docker-compose -f docker-compose.ci.yml -p test_job_test_1 down --remove-orphans --rmi all --volumes
+      run: docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: Clean up existing results
       shell: bash
-      run: rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/*.xml
+      run: sudo rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/*.xml
 
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
@@ -74,3 +74,7 @@ runs:
         name: Integration Tests
         path: test/tests/bin/results/*.xml
         reporter: jest-junit
+
+    - name: Clean up results
+      shell: bash
+      run: sudo rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/*.xml

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -28,10 +28,6 @@ runs:
         username: oauth2accesstoken
         password: ${{ steps.auth.outputs.access_token }}
 
-    - name: Clean up existing results
-      shell: bash
-      run: rm -f ./test/tests/bin/results/swagger.json test/tests/bin/results/junit.xml
-
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)


### PR DESCRIPTION
Motivation
---
 - I'm sooooooooooooooooooooooooooooooooooooooooo sick and tired of file permission errrors
 - I want to nuke junit.xml & swagger.json from our repositories

Modifications
---
 - Updated the functional test script to both PRE and POST nuke the bin/results folder/files
 - Updated the docker compose name to be variant for networking purposes

Results
---
 - The bin/results should be empty/nuked/destroyed both before and after running tests

https://tesouro.atlassian.net/browse/PAYM-2138