### PR TITLE
(PAYM-2058) - implement provider verification for profile service receiving call from payment processing

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -13,6 +13,9 @@ inputs:
   gcloud-service-account:
     description: Google Cloud service account
     required: true
+  pact-broker-token:
+    description: Read/Write token that can be used to deploy/verify pacts at tesouro.pactflow.io
+    required: false
 runs:
   using: composite
   steps:
@@ -43,7 +46,7 @@ runs:
       env:
         UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
         UNDERTEST_PACTS_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.pacts-image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
-        PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+        PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
         PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
       shell: bash
       run: |

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -48,6 +48,8 @@ runs:
         UNDERTEST_PACTS_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.pacts-image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
         PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
         PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
+        GIT_BRANCH: ${{ github.ref_name }}
+        GIT_COMMIT: ${{ github.sha }}
       shell: bash
       run: |
         # Build test container and associated services (and run tests)

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -58,6 +58,11 @@ runs:
     - name: Wait on Integration tests
       shell: bash
       run: docker wait test_${{ github.job }}-test-1
+      
+    - name: Wait on Pact Publishing
+      shell: bash
+      if: ${{ inputs.pact-broker-token }}
+      run: docker wait test_${{ github.job }}-pact-verifier-1
 
     - name: Archive swagger file
       uses: actions/upload-artifact@v3

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -49,7 +49,6 @@ runs:
         PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
         PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
         GIT_BRANCH: ${{ github.ref_name }}
-        GIT_COMMIT: ${{ github.sha }}
       shell: bash
       run: |
         # Build test container and associated services (and run tests)

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -43,6 +43,8 @@ runs:
       env:
         UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
         UNDERTEST_PACTS_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.pacts-image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
+        PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+        PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
       shell: bash
       run: |
         # Build test container and associated services (and run tests)


### PR DESCRIPTION
Motivation
---
Supply as much information as possible to the pact broker during provider verification

Modifications
---
* Provide an optional input for the PACT_BROKER_TOKEN
* Make the version, token and branch available in the environment

Results
---
From the profile service run output, we can see the PACT_BROKER_TOKEN, PROVIDER_APP_VERSION and GIT_BRANCH are all available in the environment for the test's docker compose ci file
```
Run # Build test container and associated services (and run tests)
  # Build test container and associated services (and run tests)
  export CLOUDSDK_PYTHON=python2
  docker-compose -f docker-compose.ci.yml -p test_ci-functional-tests up --build --force-recreate -d
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE: /home/ubuntu/actions-runner/_work/Tesouro.Users.Service.Profiles/Tesouro.Users.Service.Profiles/gha-creds-79cb859b85321f55.json
    GOOGLE_APPLICATION_CREDENTIALS: /home/ubuntu/actions-runner/_work/Tesouro.Users.Service.Profiles/Tesouro.Users.Service.Profiles/gha-creds-79cb859b85321f55.json
    GOOGLE_GHA_CREDS_PATH: /home/ubuntu/actions-runner/_work/Tesouro.Users.Service.Profiles/Tesouro.Users.Service.Profiles/gha-creds-79cb859b85321f55.json
    CLOUDSDK_CORE_PROJECT: tesouro-cloud
    CLOUDSDK_PROJECT: tesouro-cloud
    GCLOUD_PROJECT: tesouro-cloud
    GCP_PROJECT: tesouro-cloud
    GOOGLE_CLOUD_PROJECT: tesouro-cloud
    UNDERTEST_IMAGE: gcr.io/tesouro-cloud/tesouro-service-users-ci:0.1.34-pr-0036.6
    UNDERTEST_PACTS_IMAGE: gcr.io/tesouro-cloud/-ci:0.1.34-pr-0036.6
    PACT_BROKER_TOKEN: ***
    PROVIDER_APP_VERSION: 0.1.34-pr-0036.6
    GIT_BRANCH: 36/merge
```
