### PR TITLE
(PAYM-2147) Add `always()` to "Clean Up Results"

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -76,5 +76,6 @@ runs:
         reporter: jest-junit
 
     - name: Clean up results
+      if: always()
       shell: bash
       run: sudo rm -rf ./test/tests/bin


### PR DESCRIPTION
Motivation
---
 - I'd like to always nuke the files after functional tests run

Modifications
---
 - Updated the clean up results action to always run

Results
---
 - We will always nuke the associated results directly

https://tesouro.atlassian.net/browse/PAYM-2147