### PR TITLE
Add stage manifest inputs and bake step.

### DIFF
--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -52,8 +52,6 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
-      shell: bash
-      run: echo $GITHUB_STEP_SUMMARY
 
 # TODO: I've confirmed with Armory that this doesn't work yet. Going to comment it out and restore it in the future.
 # - name: Update Summary with Deployment link

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -52,6 +52,9 @@ runs:
         clientId: ${{ inputs.armory-client-id }}
         clientSecret: ${{ inputs.armory-client-secret }}
         path-to-file: ${{ inputs.armory-yaml-path }}
+      shell: bash
+      run: echo $GITHUB_STEP_SUMMARY
+
 # TODO: I've confirmed with Armory that this doesn't work yet. Going to comment it out and restore it in the future.
 # - name: Update Summary with Deployment link
 #   env:

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -10,11 +10,18 @@ inputs:
   armory-yaml-path:
     description: Path to the armory-deployment.yaml file.
     required: true
+  stage-kustomize-path:
+    description: Path from the project root to the stage kustomize overlay.
+    required: true
+  stage-kustomize-output-path:
+    description: Path to the baked stage manifest yaml file
+    required: false
+    default: stage-manifests.yaml
   prod-kustomize-path:
     description: Path from the project root to the production kustomize overlay.
     required: true
   prod-kustomize-output-path:
-    description: Path to the baked kustomize yaml file
+    description: Path to the baked prod manifest yaml file
     required: false
     default: prod-manifests.yaml
   working-directory:
@@ -28,6 +35,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+
+    - name: Bake Stage Manifests
+      shell: bash
+      run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-kustomize-output-path }}
 
     - name: Bake Prod Manifests
       shell: bash


### PR DESCRIPTION
Motivation
I want to bake and use the stage manifests, to deploy to the stage environment.

Modifications
I added inputs for the stage manifests.

NOTE:

- Tag this change BEFORE merging it to main.
- Adjust the applications one at a time to use the new tag, in place of @main.
        - The new tag is `@stage-deploy-update`
        - Each microservice will need to have the full stage-deployment pattern implemented first, with stage manifests/overlays and SecretProviderClass objects, and AWS updates.
- Once they are ALL converted, merge to main.
- Adjust the applications one at a time, again, back to using @main.

That way this doesn’t cause a breaking change for all the microservices.