### PR TITLE
(PAYM-2270) - Save Functional Test Container Logs

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -82,14 +82,17 @@ runs:
         name: swagger-file
         path: test/tests/bin/results/swagger.json
 
+    - name: Print Pact Generator Results
+      shell: bash
+      if: failure() && ${{ inputs.pacts-image-name }}
+      run: docker logs test_${{ github.job }}-pact-generator-1
+
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
     - name: Shut Down Containers
       if: always()
       working-directory: ./test
       shell: bash
-      run: |
-        test ${{ inputs.pacts-image-name }} && docker logs test_${{ github.job }}-pact-generator-1
-        docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
+      run: docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -95,7 +95,7 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > functional_test_docker_logs.txt
       
     - name: Archive the Docker Logs
-      uses: action/upload-artifact@v3
+      uses: actions/upload-artifact@v3
       with:
         name: functional_test_docker_logs
         path: functional_test_docker_logs.txt

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -56,10 +56,6 @@ runs:
         name: pact-file
         path: ${{ inputs.pacts-path }}
         
-    - name: Display the structure of the directory including the downloaded files
-      shell: bash
-      run: ls -lR
-
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)
@@ -96,7 +92,13 @@ runs:
     - name: Print Docker Logs
       shell: bash
       if: always()
-      run: docker compose -p test_${{ github.job }} logs -t
+      run: docker compose -p test_${{ github.job }} logs -t > functional_test_docker_logs.txt
+      
+    - name: Archive the Docker Logs
+      uses: action/upload-artifact@v3
+      with:
+        name: functional_test_docker_logs
+        path: functional_test_docker_logs.txt
 
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
     - name: Shut Down Containers

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -53,6 +53,7 @@ runs:
       uses: actions/download-artifact@v3
       with:
         name: pact-file
+        path: pacts
         
     - name: Display the structure of the directory including the downloaded files
       shell: bash

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -82,7 +82,7 @@ runs:
       shell: bash
       run: docker wait test_${{ github.job }}-test-1
       
-    - name: Wait on Pact Publishing
+    - name: Wait on Pact Verifier
       shell: bash
       if: ${{ inputs.pact-broker-token }}
       run: docker wait test_${{ github.job }}-pact-verifier-1

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -96,7 +96,7 @@ runs:
     - name: Print Docker Logs
       shell: bash
       if: always()
-      run: docker compose -p test_${{ github.job }} logs
+      run: docker compose -p test_${{ github.job }} logs -t
 
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
     - name: Shut Down Containers

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -48,6 +48,15 @@ runs:
     - name: Clean up existing results
       shell: bash
       run: sudo rm -rf ./test/tests/bin
+      
+    - name: Download pact from this build
+      uses: actions/download-artifact@v3
+      with:
+        name: pact-file
+        
+    - name: Display the structure of the directory including the downloaded files
+      shell: bash
+      run: ls -lR
 
     # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
@@ -81,11 +90,11 @@ runs:
       with:
         name: swagger-file
         path: test/tests/bin/results/swagger.json
-
-    - name: Print Pact Generator Results
+        
+    - name: Print Docker Logs
       shell: bash
       if: always()
-      run: docker logs test_${{ github.job }}-pact-generator-1
+      run: docker compose -p test_${{ github.job }} logs
 
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
     - name: Shut Down Containers

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Print Pact Generator Results
       shell: bash
-      if: failure() && ${{ inputs.pacts-image-name }}
+      if: ${{ inputs.pacts-image-name }}
       run: docker logs test_${{ github.job }}-pact-generator-1
 
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -71,11 +71,6 @@ runs:
       shell: bash
       run: docker wait test_${{ github.job }}-test-1
       
-    - name: Print Pact Generator Results
-      shell: bash
-      if: ${{ inputs.pacts-image-name }}
-      run: docker logs test_${{ github.job }}-pact-generator-1
-
     - name: Wait on Pact Publishing
       shell: bash
       if: ${{ inputs.pact-broker-token }}
@@ -92,7 +87,9 @@ runs:
       if: always()
       working-directory: ./test
       shell: bash
-      run: docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
+      run: |
+        test ${{ inputs.pacts-image-name }} && docker logs test_${{ github.job }}-pact-generator-1
+        docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
 
     - name: Report Integration Test Results
       uses: dorny/test-reporter@v1

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -70,12 +70,17 @@ runs:
     - name: Wait on Integration tests
       shell: bash
       run: docker wait test_${{ github.job }}-test-1
+      
+    - name: Print Pact Generator Results
+      shell: bash
+      if: ${{ inputs.pacts-image-name }}
+      run: docker logs test_${{ github.job }}-pact-generator-1
 
     - name: Wait on Pact Publishing
       shell: bash
       if: ${{ inputs.pact-broker-token }}
       run: docker wait test_${{ github.job }}-pact-verifier-1
-
+    
     - name: Archive swagger file
       uses: actions/upload-artifact@v3
       with:

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -84,7 +84,7 @@ runs:
 
     - name: Print Pact Generator Results
       shell: bash
-      if: ${{ inputs.pacts-image-name }}
+      if: always()
       run: docker logs test_${{ github.job }}-pact-generator-1
 
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -7,8 +7,8 @@ inputs:
   image-name:
     description: Base image name to store in GCR
     required: true
-  pacts-image-name:
-    description: Image holding the pacts for this test run
+  pacts-path:
+    description: Path relative to root where the pact files should be downloaded to
     required: false
   gcloud-service-account:
     description: Google Cloud service account
@@ -51,9 +51,10 @@ runs:
       
     - name: Download pact from this build
       uses: actions/download-artifact@v3
+      if: ${{ inputs.pacts-path }}
       with:
         name: pact-file
-        path: pacts
+        path: ${{ inputs.pacts-path }}
         
     - name: Display the structure of the directory including the downloaded files
       shell: bash


### PR DESCRIPTION
Motivation
---
When something goes wrong with the functional tests, I'm often left wondering what.  This needs to be merged to main at the same time as this [Payment Processing PR](https://github.com/tesourohq/Tesouro.Payments.Service.PaymentProcessing/actions/runs/3659442902)

Modifications
---
* Save the container logs for all of the applications running and make them available as a build artifact that can be downloaded and used for debugging issues.
* I also used this PR to address the ARM runner issue by downloading the pact file artifact created by the PaymentProcessing build

Results
---
From the [Payment Processing PR](https://github.com/tesourohq/Tesouro.Payments.Service.PaymentProcessing/actions/runs/3659442902) that is tied to this at the hip:
![image](https://user-images.githubusercontent.com/115108246/206768457-26b548cf-8cf1-475c-8def-d979d9dd4358.png)
