### PR TITLE
(PAYM-2449) add skip duplicate to create sdk action

### DIFF
--- a/create-sdk/action.yml
+++ b/create-sdk/action.yml
@@ -32,4 +32,4 @@ runs:
       shell: bash
       run: >-
         dotnet nuget add source --username USERNAME --password ${{ inputs.gh-packages-token }} --store-password-in-clear-text --name github https://nuget.pkg.github.com/tesourohq/index.json
-        && dotnet nuget push **/*.${{ inputs.nuget-version }}.nupkg -k ${{ inputs.gh-packages-token }} -s github
+        && dotnet nuget push **/*.${{ inputs.nuget-version }}.nupkg -k ${{ inputs.gh-packages-token }} -s github --skip-duplicate


### PR DESCRIPTION
Motivation
In case a ticket is closed after GitHub actions runs and then is reopened this will hopefully skip the 409 from nuget

Modifications
added skip duplicate option to nuget add source

Results
hopefully actions run!
