### PR TITLE
(PAYM-2450) add skip duplicate to package and push action

### DIFF
--- a/package-and-publish/action.yml
+++ b/package-and-publish/action.yml
@@ -62,4 +62,4 @@ runs:
       working-directory: ./src
       shell: bash
       run: >-
-        dotnet nuget push **/*.${{ inputs.sem-ver }}.nupkg -k ${{ inputs.gh-packages-token }} -s github
+        dotnet nuget push **/*.${{ inputs.sem-ver }}.nupkg -k ${{ inputs.gh-packages-token }} -s github --skip-duplicate


### PR DESCRIPTION
Motivation
In order to ignore 409 errors on duplicates you can pass this option

Modifications
added --skip-duplicate to push

Results
we can push!
