### PR TITLE
(PRODEV-1163) - Report provider results with a different reporter

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -115,6 +115,14 @@ runs:
         path: test/tests/bin/results/*.xml
         reporter: jest-junit
 
+    - name: Report Pact Provider Results
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: Pact Provider Verification
+        path: test/tests/bin/pact/*.xml
+        reporter: java-junit
+
     - name: Clean up results
       if: always()
       shell: bash

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -117,7 +117,7 @@ runs:
 
     - name: Report Pact Provider Results
       uses: dorny/test-reporter@v1
-      if: ${{ inputs.pact-broker-token }}
+      if: ${{ inputs.pact-broker-token }} && hashFiles('test/tests/bin/pact/foo*.xml')
       with:
         name: Pact Provider Verification
         #path: test/tests/bin/pact/*.xml

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -16,6 +16,9 @@ inputs:
   pact-broker-token:
     description: Read/Write token that can be used to deploy/verify pacts at tesouro.pactflow.io
     required: false
+  pact-provider-verification:
+    description: Set to true if we want to generate results from pact provider verification
+    required: false
   dockerhub-username:
     description: The Dockerhub username for the account that will pull third party images.
     required: true
@@ -117,11 +120,10 @@ runs:
 
     - name: Report Pact Provider Results
       uses: dorny/test-reporter@v1
-      if: ${{ inputs.pact-broker-token }} && hashFiles('test/tests/bin/pact/foo*.xml')
+      if: ${{ inputs.pact-provider-verification }}
       with:
         name: Pact Provider Verification
-        #path: test/tests/bin/pact/*.xml
-        path: FOO
+        path: test/tests/bin/pact/*.xml
         reporter: java-junit
 
     - name: Clean up results

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -117,7 +117,7 @@ runs:
 
     - name: Report Pact Provider Results
       uses: dorny/test-reporter@v1
-      if: always()
+      if: ${{ inputs.pact-broker-token }}
       with:
         name: Pact Provider Verification
         path: test/tests/bin/pact/*.xml

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -120,7 +120,8 @@ runs:
       if: ${{ inputs.pact-broker-token }}
       with:
         name: Pact Provider Verification
-        path: test/tests/bin/pact/*.xml
+        #path: test/tests/bin/pact/*.xml
+        path: FOO
         reporter: java-junit
 
     - name: Clean up results


### PR DESCRIPTION
Motivation
---
Provide pact verification results in our build and fail if we shouldn't deploy

Modifications
---
* The existing functional test reporter uses jest-junit format, which can't parse the output of pact's junit xml.

Results
---
Used in BillingAccounting [PR40](https://github.com/tesourohq/Tesouro.Payments.Service.BillingAccounting/actions/runs/4376737536/jobs/7659368542)
Proof that it's safe for repositories that don't specify [pact-provider-verification](https://github.com/tesourohq/Tesouro.Payments.Service.BillingAccounting/actions/runs/4378023640/jobs/7662268783)