### PR TITLE
(PAYM-1274) - pact provider verification on pact changed webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,5 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+.idea/

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -66,7 +66,7 @@ runs:
       run: |
         # Build pact verification container and associated services
         export CLOUDSDK_PYTHON=python2
-        docker-compose -f docker-compose.ci.verify-webhook.yml -p test_${{ github.job }} up pact-verifier --build --force-recreate -d
+        docker-compose -f docker-compose.ci.yml -f docker-compose.ci.verify-webhook.yml -p test_${{ github.job }} up pact-verifier --build --force-recreate -d
 
     # Here, we ask docker to wait until the Pact Verifier container is done running
     - name: Wait on Pact Verification

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -55,7 +55,7 @@ runs:
     # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
     # detached fashion :-)
     - name: Start Provider Verification Tests
-      working-directory: ./test/pacts
+      working-directory: ./test
       env:
         UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
         PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
@@ -66,7 +66,7 @@ runs:
       run: |
         # Build pact verification container and associated services
         export CLOUDSDK_PYTHON=python2
-        docker-compose -f docker-compose.ci.pacts-changed.yml -p test_${{ github.job }} up --build --force-recreate -d
+        docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} up --build --force-recreate -d
 
     # Here, we ask docker to wait until the Pact Verifier container is done running
     - name: Wait on Pact Verification
@@ -74,9 +74,28 @@ runs:
       if: ${{ inputs.pact-broker-token }}
       run: docker wait test_${{ github.job }}-pact-verifier-1
 
+    - name: Print Docker Logs
+      shell: bash
+      if: always()
+      run: docker compose -p test_${{ github.job }} logs -t > pact_verification_logs.txt
+
+    - name: Archive the Docker Logs
+      uses: actions/upload-artifact@v3
+      with:
+        name: pact_verification_logs
+        path: pact_verification_logs.txt
+
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
     - name: Shut Down Containers
       if: always()
       working-directory: ./test/pacts
       shell: bash
-      run: docker-compose -f  docker-compose.ci.pacts-changed.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
+      run: docker-compose -f  docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
+
+    - name: Report Pact Provider Results
+      uses: dorny/test-reporter@v1
+      if: always()
+      with:
+        name: Pact Provider Verification
+        path: test/tests/bin/pact/*.xml
+        reporter: java-junit

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -57,7 +57,7 @@ runs:
     - name: Start Provider Verification Tests
       working-directory: ./test
       env:
-        UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
+        UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}:latest"
         PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
         PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
         GIT_BRANCH: ${{ github.ref_name }}

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -88,7 +88,7 @@ runs:
     # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
     - name: Shut Down Containers
       if: always()
-      working-directory: ./test/pacts
+      working-directory: ./test
       shell: bash
       run: docker-compose -f  docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
 

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -93,6 +93,11 @@ runs:
       shell: bash
       run: docker-compose -f  docker-compose.ci.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes
 
+    - name: File List
+      uses: the-coding-turtle/ga-file-list@v0.4.1
+      with:
+        file_extension: "xml"        
+  
     - name: Report Pact Provider Results
       uses: dorny/test-reporter@v1
       if: always()

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -81,6 +81,7 @@ runs:
 
     - name: Archive the Docker Logs
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: pact_verification_logs
         path: pact_verification_logs.txt

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -59,7 +59,7 @@ runs:
       env:
         UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}:latest"
         PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
-        PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
+        PROVIDER_APP_VERSION: ${{ inputs.provider-version_number }}
         GIT_BRANCH: ${{ github.ref_name }}
         PACT_URL: ${{ inputs.pact-url }}
       shell: bash

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -66,7 +66,7 @@ runs:
       run: |
         # Build pact verification container and associated services
         export CLOUDSDK_PYTHON=python2
-        docker-compose -f docker-compose.ci.yml -p test_${{ github.job }} up --build --force-recreate -d
+        docker-compose -f docker-compose.ci.verify-webhook.yml -p test_${{ github.job }} up pact-verifier --build --force-recreate -d
 
     # Here, we ask docker to wait until the Pact Verifier container is done running
     - name: Wait on Pact Verification

--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -1,0 +1,82 @@
+name: Verify Contract
+description: Run provider verification for a pact
+inputs:
+  sem-ver:
+    description: Version of the package
+    required: true
+  image-name:
+    description: Base image name to store in GCR
+    required: true
+  gcloud-service-account:
+    description: Google Cloud service account
+    required: true
+  pact-broker-token:
+    description: Read/Write token that can be used to deploy/verify pacts at tesouro.pactflow.io
+    required: false
+  dockerhub-username:
+    description: The Dockerhub username for the account that will pull third party images.
+    required: true
+  dockerhub-access-token:
+    description: The PAT for the Dockerhub account.
+  pact-url:
+    description: The "permalink" URL to the newly published pact (the URL specifying the consumer version URL, rather than the "/latest" format.
+    required: true
+  provider-version_number:
+    description: The provider version number for the verification result
+    required: true
+  provider-branch:
+    description: The repository branch associated with the provider version
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Authorize with GCloud
+      id: 'auth'
+      uses: 'google-github-actions/auth@v0'
+      with:
+        token_format: access_token
+        workload_identity_provider: projects/274784588410/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-oidc-provider
+        service_account: ${{ inputs.gcloud-service-account }}
+
+    - name: Login to GCR
+      uses: docker/login-action@v2
+      with:
+        registry: gcr.io
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
+
+    - name: Login to Dockerhub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-access-token }}
+
+    # Here, we spin up the container detached. We used to use --exit-code-from, but exit once a specific container was done, but that
+    # was recently changed to exit when ANY container was done so in case we have startup or setup containers, we'll do this in a
+    # detached fashion :-)
+    - name: Start Provider Verification Tests
+      working-directory: ./test/pacts
+      env:
+        UNDERTEST_IMAGE: "gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}"
+        PACT_BROKER_TOKEN: ${{ inputs.pact-broker-token }}
+        PROVIDER_APP_VERSION: ${{ inputs.sem-ver }}
+        GIT_BRANCH: ${{ github.ref_name }}
+        PACT_URL: ${{ inputs.pact-url }}
+      shell: bash
+      run: |
+        # Build pact verification container and associated services
+        export CLOUDSDK_PYTHON=python2
+        docker-compose -f docker-compose.ci.pacts-changed.yml -p test_${{ github.job }} up --build --force-recreate -d
+
+    # Here, we ask docker to wait until the Pact Verifier container is done running
+    - name: Wait on Pact Verification
+      shell: bash
+      if: ${{ inputs.pact-broker-token }}
+      run: docker wait test_${{ github.job }}-pact-verifier-1
+
+    # should anything go wrong, we always want to nuke the containers and all orphans (startup containers)
+    - name: Shut Down Containers
+      if: always()
+      working-directory: ./test/pacts
+      shell: bash
+      run: docker-compose -f  docker-compose.ci.pacts-changed.yml -p test_${{ github.job }} down --remove-orphans --rmi all --volumes


### PR DESCRIPTION
Motivation
---
Provide an action that can be invoked by webhooks that can be fired by the pact broker when a pact changes.

Modifications
---
New action is available that runs pact provider verification with a pact located from a url.  The body looks something like this after substitutions:
```json
{
    "event_type": "contract_requiring_verification_published",
    "client_payload": {
        "pact_url": "https://tesouro.pactflow.io/pacts/provider/billingaccounting_service/consumer/funding_service/version/0.1.30",
        "consumer_name": "funding_service",
        "consumer_version_number": "0.1.30",
        "consumer_branch": "main",
        "sha": "d4dc1c1687cd8fd9022426062b9b9b277ad8018b",
        "provider_branch": "gregtest",
        "provider_version_number": "0.1.52-pr-0055.1",
        "message": "Verify changed pact for billingaccounting version 0.1.52-pr-0055.1 branch gregtest by funding 0.1.30"
    }
}
```

Results
---
From the billingaccounting webhook 
![image](https://user-images.githubusercontent.com/115108246/227989999-236e40c8-af26-424a-b0a4-55cfe133d316.png)
