### PR TITLE
(PRODEV-1389) Update to allow database migration kustomize builds

### DIFF
--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -55,7 +55,7 @@ runs:
     - name: Bake Stage Database Migration Manifest
       if: ${{ inputs.stage-kustomize-database-migration-path }} != '' # Only if passed in
       shell: bash
-      run: kustomize build ${{ inputs.stage-kustomize-database-migration-path }} -o ${{ stage-kustomize-database-migration-output-path }}
+      run: kustomize build ${{ inputs.stage-kustomize-database-migration-path }} -o ${{ inputs.stage-kustomize-database-migration-output-path }}
 
     - name: Bake Stage Manifests
       shell: bash
@@ -64,7 +64,7 @@ runs:
     - name: Bake Prod Database Migration Manifest
       if: ${{ inputs.prod-kustomize-database-migration-path }} != '' # Only if passed in
       shell: bash
-      run: kustomize build ${{ inputs.prod-kustomize-database-migration-path }} -o ${{ prod-kustomize-database-migration-output-path }}
+      run: kustomize build ${{ inputs.prod-kustomize-database-migration-path }} -o ${{ inputs.prod-kustomize-database-migration-output-path }}
 
     - name: Bake Prod Manifests
       shell: bash

--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -28,6 +28,22 @@ inputs:
     description: Working directory for the kustomize edit steps
     required: false
     default: deployment/kustomize/base
+  stage-kustomize-database-migration-path:
+    description: Path from the project root to the stage database migration kustomize overlay.
+    required: false
+    default: ''
+  stage-kustomize-database-migration-output-path:
+    description: Path to the baked stage manifest yaml file
+    required: false
+    default: stage-database-migration-manifests.yaml
+  prod-kustomize-database-migration-path:
+    description: Path from the project root to the production database migration  kustomize overlay.
+    required: false
+    default: ''
+  prod-kustomize-database-migration-output-path:
+    description: Path to the baked production manifest yaml file
+    required: false
+    default: prod-database-migration-manifests.yaml
 runs:
   using: composite
   steps:
@@ -36,9 +52,19 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 
+    - name: Bake Stage Database Migration Manifest
+      if: ${{ inputs.stage-kustomize-database-migration-path }} != '' # Only if passed in
+      shell: bash
+      run: kustomize build ${{ inputs.stage-kustomize-database-migration-path }} -o ${{ stage-kustomize-database-migration-output-path }}
+
     - name: Bake Stage Manifests
       shell: bash
       run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-kustomize-output-path }}
+
+    - name: Bake Prod Database Migration Manifest
+      if: ${{ inputs.prod-kustomize-database-migration-path }} != '' # Only if passed in
+      shell: bash
+      run: kustomize build ${{ inputs.prod-kustomize-database-migration-path }} -o ${{ prod-kustomize-database-migration-output-path }}
 
     - name: Bake Prod Manifests
       shell: bash


### PR DESCRIPTION
Motivation
---
 - I'd like to be able to get the staging and production database rollouts separated

Modifications
---
 - Added two optional parameters for the stage and prod migrations
 - Added two optional parameters for the stage and prod migration paths

Results
---
 - We can now use this version of the action to build stage and production manifests (and roll out that way)