### PR TITLE
(PRODEV-1432) - Lock armory-deploy deployment step to main branch only.

### DIFF
--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -46,6 +46,7 @@ runs:
 
       # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy
+      if: github.ref == 'refs/heads/main' # Only on main.
       id: armory-deploy
       uses: armory/cli-deploy-action@main
       with:


### PR DESCRIPTION
Motivation
---
* I want to secure the actual deployment process for any microservice that calls this action to ONLY deploy from the main branch (on a merge to main).

Modifications
---
* I added a conditional check for the main branch to the deploy step.

Results
---
* Even if an application workflow attempts to call armory-deploy off a branch other than main, this should prevent it from actually deploying.