### PR TITLE
[PRODEV-1896] GitHub action for argo deployment

### DIFF
--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -14,13 +14,13 @@ inputs:
     description: ArgoCD host.
     required: true
   github-token:
-    description: CI github token
+    description: CI github token.
     required: true
   ci-username:
-    description: CI github username
+    description: CI github username.
     required: true
   ci-email:
-    description: CI github email
+    description: CI github email.
     required: true
 runs:
   using: composite

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -14,7 +14,7 @@ inputs:
     description: ArgoCD host.
     required: true
   github-token:
-    description: Github token
+    description: CI github token
     required: true
 runs:
   using: composite

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -1,0 +1,27 @@
+name: ArgoCD Deploy
+description: Deploy using ArgoCD
+inputs:
+  argocd-application-name:
+    description: ArgoCD application name, must match the application manifest.
+    required: true
+  argocd-username:
+    description: ArgoCD service account username.
+    required: true
+  argocd-password:
+    description: ArgoCD service account password.
+    required: true
+  argocd-host:
+    description: ArgoCD host.
+    required: true
+runs:
+  using: composite
+  steps:
+      # https://docs.armory.io/cd-as-a-service/setup/gh-action/
+    - name: Deploy
+      if: github.ref == 'refs/heads/main' # Only on main.
+      id: argocd-deploy
+      shell: bash
+      run: |
+        json=$(jq -n --arg un "${{ inputs.argocd-username }}" --arg pw "${{ inputs.argocd-password }}" '{username:$un,password:$pw}')
+        token=$(curl -s -X POST "${{ inputs.argocd-host }}/api/v1/session" -d "$json" | jq --raw-output '.token')
+        curl -s -X POST "${{ inputs.argocd-host }}/api/v1/applications/${{ inputs.argocd-application-name }}/sync" -H "Authorization: Bearer $token" | jq

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -4,11 +4,8 @@ inputs:
   argocd-application-name:
     description: ArgoCD application name, must match the application manifest.
     required: true
-  argocd-username:
-    description: ArgoCD service account username.
-    required: true
-  argocd-password:
-    description: ArgoCD service account password.
+  argocd-apikey:
+    description: ArgoCD service account api-key.
     required: true
   argocd-host:
     description: ArgoCD host.
@@ -48,6 +45,4 @@ runs:
       id: argocd-deploy
       shell: bash
       run: |
-        json=$(jq -n --arg un "${{ inputs.argocd-username }}" --arg pw "${{ inputs.argocd-password }}" '{username:$un,password:$pw}')
-        token=$(curl -s -X POST "${{ inputs.argocd-host }}/api/v1/session" -d "$json" | jq --raw-output '.token')
-        curl -s -X POST "${{ inputs.argocd-host }}/api/v1/applications/${{ inputs.argocd-application-name }}/sync" -H "Authorization: Bearer $token" | jq
+        curl -s -X POST "${{ inputs.argocd-host }}/api/v1/applications/${{ inputs.argocd-application-name }}/sync" -H "Authorization: Bearer ${{ inputs.argocd-apikey }}" | jq

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -19,6 +19,12 @@ inputs:
   ci-email:
     description: CI github email.
     required: true
+  semver:
+    description: Semantic Version.
+    required: true
+  image-name:
+    description: Tagged image name to be deployed.
+    required: true
 runs:
   using: composite
   steps:
@@ -28,12 +34,13 @@ runs:
         token: ${{ inputs.github-token }}
 
     # Commit and push.
-    - name: Apply sha to version
+    - name: Apply semver-sha to version
       shell: bash
       # Only run on main branch push (e.g. pull request merge).
       if: github.event_name == 'push'
       run: |
-        yq e '.spec.template.metadata.labels.version = "${{ github.sha }}"' -i ./deployment/kustomize/base/deployment.yaml
+        yq -i '.spec.template.metadata.labels.version = "${{ inputs.semver }}-${{ github.sha }}"' ./deployment/kustomize/base/deployment.yaml
+        yq -i '.spec.template.spec.containers[0].image = "${{ inputs.image-name }}"' ./deployment/kustomize/base/deployment.yaml
         git config --global user.name "${{ inputs.ci-username }}"
         git config --global user.email "${{ inputs.ci-email }}"
         git add

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -16,7 +16,6 @@ inputs:
 runs:
   using: composite
   steps:
-      # https://docs.armory.io/cd-as-a-service/setup/gh-action/
     - name: Deploy
       if: github.ref == 'refs/heads/main' # Only on main.
       id: argocd-deploy

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -13,9 +13,30 @@ inputs:
   argocd-host:
     description: ArgoCD host.
     required: true
+  github-token:
+    description: Github token
+    required: true
 runs:
   using: composite
   steps:
+    - name: CheckoutRepo
+      uses: actions/checkout@v3
+      with:
+        token: ${{ inputs.github-token }}
+
+    # Commit and push.
+    - name: Apply sha to version
+      shell: bash
+      # Only run on main branch push (e.g. pull request merge).
+      if: github.event_name == 'push'
+      run: |
+        yq e '.spec.template.metadata.labels.version = "${{ github.sha }}"' -i ./deployment/kustomize/base/deployment.yaml
+        git config --global user.name "ci-tesouro"
+        git config --global user.email "ci@tesouro.com"
+        git add
+        git commit -m "Version Increment"
+        git push
+
     - name: Deploy
       if: github.ref == 'refs/heads/main' # Only on main.
       id: argocd-deploy

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -16,6 +16,12 @@ inputs:
   github-token:
     description: CI github token
     required: true
+  ci-username:
+    description: CI github username
+    required: true
+  ci-email:
+    description: CI github email
+    required: true
 runs:
   using: composite
   steps:
@@ -31,10 +37,10 @@ runs:
       if: github.event_name == 'push'
       run: |
         yq e '.spec.template.metadata.labels.version = "${{ github.sha }}"' -i ./deployment/kustomize/base/deployment.yaml
-        git config --global user.name "ci-tesouro"
-        git config --global user.email "ci@tesouro.com"
+        git config --global user.name "${{ inputs.ci-username }}"
+        git config --global user.email "${{ inputs.ci-email }}"
         git add
-        git commit -m "Version Increment"
+        git commit -m "Versioning Commit"
         git push
 
     - name: Deploy


### PR DESCRIPTION
Motivation
---
Need a way to apply a unique version and deploy via ArgoCD.

Modifications
---
I added an action template to apply the github.sha of the triggering workflow as the deployment version. Then it initiates a deployment sync for the calling app.

Results
---
MVP of ArgoCD app deployment (sync) action.