### PR TITLE
(PRODEV-2003) - Make stage manifests optional for armory-deploy.

### DIFF
--- a/armory-deploy/action.yaml
+++ b/armory-deploy/action.yaml
@@ -12,7 +12,7 @@ inputs:
     required: true
   stage-kustomize-path:
     description: Path from the project root to the stage kustomize overlay.
-    required: true
+    required: false
   stage-kustomize-output-path:
     description: Path to the baked stage manifest yaml file
     required: false
@@ -58,6 +58,7 @@ runs:
       run: kustomize build ${{ inputs.stage-kustomize-database-migration-path }} -o ${{ inputs.stage-kustomize-database-migration-output-path }}
 
     - name: Bake Stage Manifests
+      if: ${{ inputs.stage-kustomize-path != '' }} # Only if passed in
       shell: bash
       run: kustomize build ${{ inputs.stage-kustomize-path }} -o ${{ inputs.stage-kustomize-output-path }}
 


### PR DESCRIPTION
Motivation
---
I want the stage manifests to be optional as a parameter, so we can use this action more flexibly.

Modifications
---
* I made the stage-manifest-path input optional, and added a check to only execute the step for baking them if a value is passed in.

Results
---
* The action will now bypass baking the stage manifests if nothing is passed in.
* This also, however will fail if the armory-deployment configuration that is passed in tries to reference stage manifests, which will no longer be there.
