### PR TITLE
[PRODEV-2089] semver . run_attempt for unique deployment version

### DIFF
--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -42,7 +42,7 @@ runs:
       # Only run on main branch push (e.g. pull request merge).
       if: github.event_name == 'push'
       run: |
-        yq -i '.spec.template.metadata.labels.version = "${{ inputs.semver }}-${{ github.sha }}"' ${{ inputs.path-to-version-patch }}
+        yq -i '.spec.template.metadata.labels.version = "${{ inputs.semver }}.${{ github.run_attempt }}"' ${{ inputs.path-to-version-patch }}
         yq -i '.spec.template.spec.containers[0].image = "${{ inputs.image-name }}"' ${{ inputs.path-to-version-patch }}
         git config --global user.name "${{ inputs.ci-username }}"
         git config --global user.email "${{ inputs.ci-email }}"


### PR DESCRIPTION
Motivation
---
Deploying with the github sha wasn't working. It also wasn't going to be unique for action re-runs.

Modifications
---
Switched github sha for github run-attempt.

Results
---
Unique deployment versions per run attempt