### PR TITLE
[PRODEV-2105] Add sha back to version, commit to release branch

### DIFF
--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -42,11 +42,13 @@ runs:
       # Only run on main branch push (e.g. pull request merge).
       if: github.event_name == 'push'
       run: |
-        yq -i '.spec.template.metadata.labels.version = "${{ inputs.semver }}.${{ github.run_attempt }}"' ${{ inputs.path-to-version-patch }}
+        git checkout release
+        git merge --no-commit main
+        yq -i '.spec.template.metadata.labels.version = "${{ inputs.semver }}.${{ github.run_attempt }}-${{ github.sha }}"' ${{ inputs.path-to-version-patch }}
         yq -i '.spec.template.spec.containers[0].image = "${{ inputs.image-name }}"' ${{ inputs.path-to-version-patch }}
         git config --global user.name "${{ inputs.ci-username }}"
         git config --global user.email "${{ inputs.ci-email }}"
-        git commit -a -m "Versioning Commit"
+        git commit -a -m "Version ${{ inputs.semver }}.${{ github.run_attempt }}-${{ github.sha }}"
         git push
 
     - name: Deploy


### PR DESCRIPTION
Motivation
---
It's a headache to risk an infinite action loop by running a versioning commit on main in an action.

Modifications
---
Merge into release branch with versioning commit.

Results
---
A deployment branch that reflects actual deployment state.