### PR TITLE
(PRODEV-2289) - better debugging when actions fail

### DIFF
--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -106,6 +106,7 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > functional_test_docker_logs.txt
       
     - name: Archive the Docker Logs
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: functional_test_docker_logs

--- a/functional-tests/action.yml
+++ b/functional-tests/action.yml
@@ -106,8 +106,8 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > functional_test_docker_logs.txt
       
     - name: Archive the Docker Logs
-      if: always()
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: functional_test_docker_logs
         path: functional_test_docker_logs.txt


### PR DESCRIPTION
Motivation
---
When the functional tests fail for unexpected reasons, I want the docker logs.

Modifications
---
just an `always` flag on this step

Results
---
even when the docker test container fails with an exit code of 1, we get the docker logs as in this [result](https://github.com/tesourohq/Tesouro.Payments.Service.CoreTransaction/actions/runs/5360134830)