### PR TITLE
(PRODEV-4305) Add GH_PACKAGES_TOKEN to pact verification

### DIFF
--- a/contract-requiring-verification-published/action.yml
+++ b/contract-requiring-verification-published/action.yml
@@ -27,6 +27,9 @@ inputs:
   provider-branch:
     description: The repository branch associated with the provider version
     required: true
+  gh-packages-token:
+    description: Github packages token
+    required: false
 runs:
   using: composite
   steps:
@@ -62,6 +65,7 @@ runs:
         PROVIDER_APP_VERSION: ${{ inputs.provider-version_number }}
         GIT_BRANCH: ${{ github.ref_name }}
         PACT_URL: ${{ inputs.pact-url }}
+        GH_PACKAGES_TOKEN: ${{ inputs.gh-packages-token }}
       shell: bash
       run: |
         # Build pact verification container and associated services


### PR DESCRIPTION
Motivation
---
 - We'd like our pact verifications to work correctly
 - We need the GH_PACKAGES_TOKEN in order to properly install certain packages

Modifications
---
 - Added GH_PACKAGES_TOKEN as a param
 - Passed GH_PACKAGES_TOKEN into docker-compose.ci.yml

Results
---
 - Pact verification should work now