### PR TITLE
(PRODEV-4477) Add ECR docker build action

### DIFF
--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -1,0 +1,79 @@
+name: Build docker images ecr
+description: Build docker images ecr
+inputs:
+  sem-ver:
+    description: Version of the package
+    required: true
+  AssemblySemVer:
+    description: Version of the Assembly
+    required: true
+  gh-packages-token:
+    description: Github packages token
+    required: true
+  dockerfile-path:
+    description: The location of the project Dockerfile
+    required: true
+  image-name:
+    description: Base image name to store in ECR
+    required: true
+  aws-github-role:
+    description: AWS role to assume
+    required: true
+  aws-region:
+    description: AWS region ECR repository is in.
+    required: true
+  aws-repository-name:
+    description: AWS ECR repository name.
+    required: true
+  docker-context:
+    description: The context folder where the image is built
+    required: true
+  platform:
+    description: The platform to target for the build
+    default: linux/arm64
+  dockerhub-username:
+    description: The Dockerhub username for the account that will pull third party images.
+    required: true
+  dockerhub-access-token:
+    description: The PAT for the Dockerhub account.
+outputs:
+  image-tag:
+    description: The tag (other than 'latest') applied to the image and pushed.
+    value: ${{ inputs.sem-ver }}
+  image-name:
+    description: The full name of the image that was built and pushed.
+    value: gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
+runs:
+  using: composite
+  steps:
+    - name: Login to Dockerhub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-access-token }}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ inputs.aws-github-role }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+
+    # a note here, the actions docker/metadata-action & docker/build-push-action were not built with building on arm architecture in mind. The environment
+    # file used specifies specific linux/amd64 items making building the container impossible (for now)
+    # we'll run our own command for now, but as GitHub Actions releases arm runners (and actions add support), we could switch back
+    - name: Build Arm Image
+      env:
+        REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REPOSITORY: ${{ inputs.aws-repository-name }}
+      shell: bash
+      run: docker buildx build ${{ inputs.docker-context }} -f ${{ inputs.dockerfile-path }}/Dockerfile --build-arg GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }} --build-arg ASSEMBLY_VERSION=${{ inputs.AssemblySemVer }} --tag gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }} --tag gcr.io/tesouro-cloud/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest --push --platform ${{ inputs.platform }}


### PR DESCRIPTION
Motivation
---
We want to test ECR as a primary repository.

Modifications
---
Add a ECR build-docker-images action

Results
---
We can now test building and pushing to ECR as an optional replacement for GCR.