### PR TITLE
(PRODEV-4656) Update to latest SDK

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   dotnet-version:
     description: The version of .NET for Setup task
-    default: 7.0.100
+    default: 7.0.*
     required: false
   code-coverage:
     description: The code coverage lower and upper threshold percentages for badge and health indicators

--- a/package-and-publish/action.yml
+++ b/package-and-publish/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   dotnet-version:
     description: The version of .NET for Setup task
-    default: 7.0.100
+    default: 7.0.*
     required: false
   sem-ver:
     description: Version of the package


### PR DESCRIPTION
Motivation
---
 - We want the latest SDK for all our actions by default

Modifications
---
 - Update commands to default to latest SDK

Results
---
 - This really doesn't change anything since nearly ALL of our services override this command but I don't want `7.0.100` to exist in our code base