### PR TITLE
(PRODEV-5010) - Add Image Scanning to CI

### DIFF
--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -96,14 +96,9 @@ runs:
         image: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
         only-severities: critical
         only-fixed: true
-        sarif-file: 'scout-results.sarif'
+        summary: true
+        write-comment: true
         exit-code: true
-    
-    - name: Post Scan Results - Docker Scout
-      uses: github/codeql-action/upload-sarif@v2
-      if: always()
-      with:
-        sarif_file: 'scout-results.sarif'
     
     - name: Scan Image - Trivy
       uses: aquasecurity/trivy-action@master
@@ -113,15 +108,7 @@ runs:
         image-ref: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
         severity: CRITICAL
         ignore-unfixed: true
-        format: 'sarif'
-        output: 'trivy-results.sarif'
         exit-code: '1'
-    
-    - name: Post Scan Results - Trivy
-      uses: github/codeql-action/upload-sarif@v2
-      if: always()
-      with:
-        sarif_file: 'trivy-results.sarif'
 
     # This will not build the image again. It sees the local image and just pushes that (ref: https://docs.docker.com/build/ci/github-actions/test-before-push/).
     - name: Push

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -84,7 +84,7 @@ runs:
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
     
-    - name: Scan Image - Docker Scout
+    - name: Scan Image
       id: scan
       uses: docker/scout-action@v1
       with:
@@ -102,6 +102,8 @@ runs:
       shell: bash
       run: |
         cat scout-results.json >> $GITHUB_STEP_SUMMARY
+    
+    # TODO: Could create and upload and SBOM here?
 
     # This will not build the image again. It sees the local image and just pushes that (ref: https://docs.docker.com/build/ci/github-actions/test-before-push/).
     - name: Push

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -101,7 +101,7 @@ runs:
       id: post-results
       shell: bash
       run: |
-        echo -e "Scan Results\n\n" && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
+        echo ":mag: ### Scan Results: <br><br>" && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -94,7 +94,14 @@ runs:
         only-fixed: true
         summary: true
         write-comment: true
+        sarif-file: scout-results.json
         exit-code: true
+    
+    - name: Post Sarif File
+      id: post-results
+      shell: bash
+      run: |
+        cat scout-results.json >> $GITHUB_STEP_SUMMARY
 
     # This will not build the image again. It sees the local image and just pushes that (ref: https://docs.docker.com/build/ci/github-actions/test-before-push/).
     - name: Push

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -101,7 +101,7 @@ runs:
       id: post-results
       shell: bash
       run: |
-        echo ":mag: ### Scan Results: <br><br>" && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
+        echo ":mag: ### Scan Results: <br><br>" >> $GITHUB_STEP_SUMMARY && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -69,6 +69,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: Build
+      id: build
       uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.docker-context }}
@@ -84,6 +85,7 @@ runs:
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
     
     - name: Scan Image - Docker Scout
+      id: scan
       uses: docker/scout-action@v1
       with:
         command: cves
@@ -96,12 +98,8 @@ runs:
 
     # This will not build the image again. It sees the local image and just pushes that (ref: https://docs.docker.com/build/ci/github-actions/test-before-push/).
     - name: Push
-      uses: docker/build-push-action@v5
-      with:
-        context: ${{ inputs.docker-context }}
-        platforms: ${{ inputs.platform }}
-        push: true
-        file: ${{ inputs.dockerfile-path }}/Dockerfile
-        tags: |
-          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
-          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
+      if: steps.build.outcome == 'success' && steps.scan.outcome == 'success'
+      shell: bash
+      run: |
+        docker push ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
+        docker push ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -101,7 +101,7 @@ runs:
       id: post-results
       shell: bash
       run: |
-        cat scout-results.json >> $GITHUB_STEP_SUMMARY
+        echo -e "#Scan Results\n\n" && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -101,7 +101,7 @@ runs:
       id: post-results
       shell: bash
       run: |
-        echo -e "#Scan Results\n\n" && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
+        echo -e "Scan Results\n\n" && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -88,7 +88,7 @@ runs:
       id: scan
       uses: docker/scout-action@v1
       with:
-        command: cves
+        command: quickview,cves,sbom
         image: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
         only-severities: critical
         only-fixed: true
@@ -97,15 +97,16 @@ runs:
         sarif-file: scout-results.json
         exit-code: true
     
-    # BUG: WHY WILL IT NOT FORMAT???
     - name: Post Sarif File
       id: post-results
       shell: bash
       run: |
         echo '---' >> $GITHUB_STEP_SUMMARY
-        echo ':mag: ###Scan Results: <br><br>' >> $GITHUB_STEP_SUMMARY
+        echo ':mag: Scan Results: <br><br>' >> $GITHUB_STEP_SUMMARY
         cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
         echo '---' >> $GITHUB_STEP_SUMMARY
+    
+    
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -101,7 +101,7 @@ runs:
       id: post-results
       shell: bash
       run: |
-        echo ":mag: ### Scan Results: <br><br>" >> $GITHUB_STEP_SUMMARY && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
+        echo ':mag: ### Scan Results: <br><br>' >> $GITHUB_STEP_SUMMARY && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -68,16 +68,65 @@ runs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
-    - name: Build and push
+    - name: Build
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ inputs.docker-context }}
+        platforms: ${{ inputs.platform }}
+        push: false
+        file: ${{ inputs.dockerfile-path }}/Dockerfile
+        build-args: |
+          ASSEMBLY_VERSION=${{ inputs.AssemblySemVer }}
+          GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }}
+        tags: |
+          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
+          ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
+         
+    # TODO: I want this step to fail if critical CVEs are found.
+    - name: Scan Image - Docker Scout
+      uses: docker/scout-action@v1
+      with:
+        command: cves
+        image: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
+        only-severities: critical
+        only-fixed: true
+        write-comment: true
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        sarif-file: 'scout-results.sarif'
+        exit-code: true
+    
+    - name: Post Scan Results - Docker Scout
+      uses: github/codeql-action/upload-sarif@v2
+      if: always()
+      with:
+        sarif_file: 'scout-results.sarif'
+    
+    - name: Scan Image - Trivy
+      uses: aquasecurity/trivy-action@master
+      with:
+        scan-type: image
+        scanners: vuln
+        image-ref: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
+        severity: CRITICAL
+        ignore-unfixed: true
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        exit-code: '1'
+    
+    - name: Post Scan Results - Trivy
+      uses: github/codeql-action/upload-sarif@v2
+      if: always()
+      with:
+        sarif_file: 'trivy-results.sarif'
+
+    # This will not build the image again. It sees the local image and just pushes that (ref: https://docs.docker.com/build/ci/github-actions/test-before-push/).
+    - name: Push
       uses: docker/build-push-action@v5
       with:
         context: ${{ inputs.docker-context }}
         platforms: ${{ inputs.platform }}
         push: true
         file: ${{ inputs.dockerfile-path }}/Dockerfile
-        build-args: |
-          ASSEMBLY_VERSION=${{ inputs.AssemblySemVer }}
-          GH_PACKAGES_TOKEN=${{ inputs.gh-packages-token }}
         tags: |
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -90,8 +90,6 @@ runs:
         image: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
         only-severities: critical
         only-fixed: true
-        write-comment: true
-        github-token: ${{ secrets.GITHUB_TOKEN }}
         sarif-file: 'scout-results.sarif'
         exit-code: true
     

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -74,6 +74,7 @@ runs:
         context: ${{ inputs.docker-context }}
         platforms: ${{ inputs.platform }}
         push: false
+        load: true
         file: ${{ inputs.dockerfile-path }}/Dockerfile
         build-args: |
           ASSEMBLY_VERSION=${{ inputs.AssemblySemVer }}

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -81,6 +81,11 @@ runs:
         tags: |
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
+    
+    - name: Where My Images At?
+      shell: bash
+      run: |
+        docker images
          
     # TODO: I want this step to fail if critical CVEs are found.
     - name: Scan Image - Docker Scout
@@ -91,6 +96,7 @@ runs:
         only-severities: critical
         only-fixed: true
         sarif-file: 'scout-results.sarif'
+        summary: true
         exit-code: true
     
     - name: Post Scan Results - Docker Scout

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -83,12 +83,6 @@ runs:
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
           ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
     
-    - name: Where My Images At?
-      shell: bash
-      run: |
-        docker images
-         
-    # TODO: I want this step to fail if critical CVEs are found.
     - name: Scan Image - Docker Scout
       uses: docker/scout-action@v1
       with:
@@ -99,16 +93,6 @@ runs:
         summary: true
         write-comment: true
         exit-code: true
-    
-    - name: Scan Image - Trivy
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: image
-        scanners: vuln
-        image-ref: local://${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:latest
-        severity: CRITICAL
-        ignore-unfixed: true
-        exit-code: '1'
 
     # This will not build the image again. It sees the local image and just pushes that (ref: https://docs.docker.com/build/ci/github-actions/test-before-push/).
     - name: Push

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -97,11 +97,15 @@ runs:
         sarif-file: scout-results.json
         exit-code: true
     
+    # BUG: WHY WILL IT NOT FORMAT???
     - name: Post Sarif File
       id: post-results
       shell: bash
       run: |
-        echo ':mag: ### Scan Results: <br><br>' >> $GITHUB_STEP_SUMMARY && cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
+        echo '---' >> $GITHUB_STEP_SUMMARY
+        echo ':mag: ###Scan Results: <br><br>' >> $GITHUB_STEP_SUMMARY
+        cat scout-results.json | jq '.runs[].results?' >> $GITHUB_STEP_SUMMARY
+        echo '---' >> $GITHUB_STEP_SUMMARY
     
     # TODO: Could create and upload and SBOM here?
 

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -97,7 +97,6 @@ runs:
         only-severities: critical
         only-fixed: true
         sarif-file: 'scout-results.sarif'
-        summary: true
         exit-code: true
     
     - name: Post Scan Results - Docker Scout


### PR DESCRIPTION
NOTE: Merge this after all the permission updates have gone through.

Motivation
---
I want our images to be scanned for critical CVEs during CI, and for CI to fail when they are detected, so we can enforce resolution of these vulnerabilities as a part of development rather than in response to discovery. I also want a report of the scans to be posted for reference during resolution, and for auditing.

Modifications
---
I added image scanning, report-generation, and CI failure to the `build-docker-images-ecr` action.

Results
---
Images are now required to be free from critical CVEs before a PR can be merged.
