### PR TITLE
(PRODEV-5264) - Shift Dockerhub auth to avoid rate limit

### DIFF
--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -46,17 +46,17 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-access-token }}
+    
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Motivation
---
I want to avoid being rate-limited by dockerhub.

Modifications
---
* We were avoiding it, except for the during the steps ABOVE where we auth, one of which (the qemu setup step) pulls an image. That was happening anonymously, and was subject to the 100/6hrs rate limit. So... I moved the auth above that.

Results
---
Should avoid the rate limit now.

"But Ben... the branch and ticket here say that you are going to add more details about how much quota we have left!"
"That's right, but you know what Dockerhub can't tell you if you are on a paid plan? You guessed it: your current quota usage. Oh they'll tell you if you are anonymous, or an individual, but if you are on a paid plan they just don't return that header to you, because it's a SECRET."
(In all seriousness, I put a support request in for this. Seems dumb, but this is actually what their docs say)