### PR TITLE
(PRODEV-6088) - Stop pushing provenance metadata to ECR

### DIFF
--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -76,6 +76,7 @@ runs:
         platforms: ${{ inputs.platform }}
         push: true
         load: false
+        provenance: false
         file: ${{ inputs.dockerfile-path }}/Dockerfile
         build-args: |
           ASSEMBLY_VERSION=${{ inputs.AssemblySemVer }}


### PR DESCRIPTION
Motivation
---
I want to stop pushing unnecessary stuff to ECR. ECR wrongly interprets this artifacts as "images" and they mess up our lifecycle rules and UI.

Modifications
---
I disabled the provenance metadata.

Results
---
No more pushes of that stuff to ECR.