### PR TITLE
(PRODEV-6129) Increment GHA versions to stop using set output

### DIFF
--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -43,7 +43,7 @@ runs:
   using: composite
   steps:
     - name: CheckoutRepo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ inputs.github-token }}
         fetch-depth: 0

--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -19,7 +19,7 @@ runs:
   using: composite
   steps:
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
         include-prerelease: false
@@ -59,7 +59,7 @@ runs:
       # gets all output files from Coverlet (one per test project) and combines into a single file
       # creates a Markdown file with coverage per class
     - name: Add Coverage Report
-      uses: danielpalme/ReportGenerator-GitHub-Action@5.1.10
+      uses: danielpalme/ReportGenerator-GitHub-Action@5.2.1
       with:
         reports: ${{ runner.temp }}/*/coverage.cobertura.xml
         targetdir: ${{ runner.temp }}

--- a/contract-requiring-verification-published-ecr/action.yml
+++ b/contract-requiring-verification-published-ecr/action.yml
@@ -82,7 +82,7 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > pact_verification_logs.txt
 
     - name: Archive the Docker Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: pact_verification_logs

--- a/create-sdk/action.yml
+++ b/create-sdk/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: (SDK) Download Swagger File
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: swagger-file
         path: test/tests/bin/results/updates

--- a/functional-tests-ecr/action.yml
+++ b/functional-tests-ecr/action.yml
@@ -50,7 +50,7 @@ runs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: Login to Dockerhub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-access-token }}
@@ -60,7 +60,7 @@ runs:
       run: sudo rm -rf ./test/tests/bin
       
     - name: Download pact from this build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       if: ${{ inputs.pacts-path }}
       with:
         name: pact-file
@@ -100,7 +100,7 @@ runs:
       run: docker wait test_${{ github.job }}-rover-1
       
     - name: Archive swagger file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: swagger-file
         path: test/tests/bin/results/swagger.json
@@ -111,7 +111,7 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > functional_test_docker_logs.txt
       
     - name: Archive the Docker Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: functional_test_docker_logs

--- a/get-version/action.yml
+++ b/get-version/action.yml
@@ -20,12 +20,12 @@ runs:
   using: composite
   steps:
     - name: Install GitVersion
-      uses: gittools/actions/gitversion/setup@v0.9.15
+      uses: gittools/actions/gitversion/setup@v0.11.0
       with:
         versionSpec: "5.11.1"
 
     - name: Determine Version
       id: gitversion
-      uses: gittools/actions/gitversion/execute@v0.9.15
+      uses: gittools/actions/gitversion/execute@v0.11.0
       with:
         useConfigFile: true

--- a/package-and-publish/action.yml
+++ b/package-and-publish/action.yml
@@ -24,12 +24,12 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
         include-prerelease: false


### PR DESCRIPTION
Motivation
---
GH will at some point, supposedly, stop supporting set output commands. We're using a bunch of other ppls actions that are still using them on their current version.

Modifications
---
- Increment action versions that are yelling in other repos

Results
---
Less yelling