### PR TITLE
(PRODEV-6721) Upload all the test project results - not just last one

### DIFF
--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -46,14 +46,14 @@ runs:
     - name: Test
       working-directory: ./src
       shell: bash
-      run: dotnet test --no-build -c Release -l 'trx;LogFileName=${{ runner.temp }}/results.trx' ${{ inputs.solution-file }} --collect:"XPlat Code Coverage" --results-directory ${{ runner.temp }}
+      run: dotnet test --no-build -c Release -l 'trx;LogFilePrefix=${{ runner.temp }}/results' ${{ inputs.solution-file }} --collect:"XPlat Code Coverage" --results-directory ${{ runner.temp }}
 
     - name: Test Report
       uses: dorny/test-reporter@v1
       if: always()
       with:
         name: Unit Tests
-        path: ${{ runner.temp }}/results.trx
+        path: ${{ runner.temp }}/results*trx
         reporter: dotnet-trx
            
       # gets all output files from Coverlet (one per test project) and combines into a single file


### PR DESCRIPTION
Motivation
---
https://tesourohq.slack.com/archives/C02FJBY4JJD/p1710875444744629 - if a solution had multiple projects - it would leave only the last one.

Modifications
---
Use the prefix option for test output rather than file.  Every file gets tagged with a timestamp so we don't eat them.

Results
---
https://github.com/tesourohq/Tesouro.Payments.Service.CoreTransaction/pull/424/checks?check_run_id=22851896651