### PR TITLE
(PRODEV-7239) Add N image versioning to ArgoCD Deploy action.

### DIFF
--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -88,7 +88,7 @@ runs:
       shell: bash
       if: github.ref == 'refs/heads/main' && inputs.path-to-overlays != '' && inputs.versioned-image-names != ''
       run: |
-        NAMES=${{ inputs.versioned-image-names }}
+        NAMES="${{ inputs.versioned-image-names }}"
         for dir in ${{ inputs.path-to-overlays }}*/; do for name in NAMES; do yq -i '.images += [{"name": "$name"} + {"newTag": "${{ inputs.semver }}"}]' "$dir""kustomization.yaml"; done; done
 
     - name: Commit and push

--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -39,6 +39,10 @@ inputs:
     description: Path from the project root to the database migration kustomize overlays.
     required: false
     default: ''
+  versioned-image-names:
+    description: Space delimited list of image names to be versioned on deploy.
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -79,6 +83,13 @@ runs:
       if: github.ref == 'refs/heads/main' && inputs.path-to-overlays != ''
       run: |
         for dir in ${{ inputs.path-to-overlays }}*/; do yq e '.labels.[0].pairs.semver = "${{ inputs.semver }}"' -i "$dir""kustomization.yaml"; yq e '.labels.[0].pairs."app.kubernetes.io/version" = "${{ inputs.semver }}"' -i "$dir""kustomization.yaml"; done
+
+    - name: Version images
+      shell: bash
+      if: github.ref == 'refs/heads/main' && inputs.path-to-overlays != '' && inputs.versioned-image-names != ''
+      run: |
+        NAMES=${{ inputs.versioned-image-names }}
+        for dir in ${{ inputs.path-to-overlays }}*/; do for name in NAMES; do yq -i '.images += [{"name": "$name"} + {"newTag": "${{ inputs.semver }}"}]' "$dir""kustomization.yaml"; done; done
 
     - name: Commit and push
       shell: bash

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -43,6 +43,9 @@ outputs:
   image-name:
     description: The full name of the image that was built and pushed.
     value: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}:${{ inputs.sem-ver }}
+  image-name-without-tag:
+    description: The name of the image sans the tag.
+    value: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.aws-repository-name }}/${{ inputs.image-name }}${{ github.event_name == 'pull_request' && '-ci' || '' }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
Motivation
---
A flexible image versioning parameter that will work regardless of the number of dependent versioned images.

Modifications
---
- Added backwards compatible version images block, this appends an images block to the kustomize overlays leveraging the images transformer to apply versioning.
- Added backwards compatible image-name-without-tag output to our build action for later consumption in ArgoCD-Deploy.

Results
---
💪 