### PR TITLE
(PRODEV-7509)Check exit codes when running tests

### DIFF
--- a/functional-tests-ecr/action.yml
+++ b/functional-tests-ecr/action.yml
@@ -91,22 +91,42 @@ runs:
     # Here, we ask docker to wait until the Jest test container is done running
     - name: Wait on Functional tests
       shell: bash
-      run: docker wait test_${{ github.job }}-test-1
+      run: |
+        exit_code=$(docker wait test_${{ github.job }}-test-1)
+        if [ "$exit_code" -ne 0 ]; then
+          echo "Functional tests failed with exit code $exit_code"
+          exit $exit_code
+        fi
       
     - name: Wait on BDD Tests (Cucumber)
       shell: bash
       if: ${{ inputs.bdd-flag == 'true' }}
-      run: docker wait test_${{ github.job }}-cucumber-test-1
+      run: |
+        exit_code=$(docker wait test_${{ github.job }}-cucumber-test-1)
+        if [ "$exit_code" -ne 0 ]; then
+          echo "Cucumber tests failed with exit code $exit_code"
+          exit $exit_code
+        fi 
 
     - name: Wait on Pact Verifier
       shell: bash
       if: ${{ inputs.pact-broker-token }}
-      run: docker wait test_${{ github.job }}-pact-verifier-1
+      run: |
+        exit_code=$(docker wait test_${{ github.job }}-pact-verifier-1)
+        if [ "$exit_code" -ne 0 ]; then
+          echo "PACT tests failed with exit code $exit_code"
+          exit $exit_code
+        fi
       
     - name: Wait on Rover
       shell: bash
       if: ${{ inputs.rover-flag }}
-      run: docker wait test_${{ github.job }}-rover-1
+      run: |
+        exit_code=$(docker wait test_${{ github.job }}-rover-1)
+        if [ "$exit_code" -ne 0 ]; then
+          echo "Rover failed with exit code $exit_code"
+          exit $exit_code
+        fi 
       
     - name: Archive swagger file
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Motivation
---
Fx tests are failing due to being unable to find a module due to case sensitivity. The test reporter sees these as skipped, not failed, so testing passes.

Modifications
---
Check exist code for tests and fail if need be

Results
---
consistent testing!