### PR TITLE
(PRODEV-7755) - update GHA version numbers to get version from secrets Actions

### DIFF
--- a/argocd-deploy/action.yaml
+++ b/argocd-deploy/action.yaml
@@ -47,7 +47,7 @@ runs:
   using: composite
   steps:
     - name: CheckoutRepo
-      uses: actions/checkout@v3
+      uses: actions/checkout@ACTIONS_CHECKOUT_VERSION
       with:
         token: ${{ inputs.github-token }}
         fetch-depth: 0

--- a/branch-locking/action.yaml
+++ b/branch-locking/action.yaml
@@ -20,7 +20,7 @@ runs:
     - name: Generate a token
       id: generate_token
       if: github.ref == 'refs/heads/main'
-      uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92
+      uses: tibdex/github-app-token@ACTIONS_GITHUBAPPTOKEN_VERSION
       with:
         app_id: ${{ inputs.app-id }}
         private_key: ${{ inputs.app-pem }}

--- a/build-and-test/action.yml
+++ b/build-and-test/action.yml
@@ -19,12 +19,12 @@ runs:
   using: composite
   steps:
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@ACTIONS_SETUPDOTNET_VERSION
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
         include-prerelease: false
         
-    - uses: actions/cache@v2
+    - uses: actions/cache@ACTIONS_CACHE_VERSION
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/build-docker-images-ecr/action.yml
+++ b/build-docker-images-ecr/action.yml
@@ -50,7 +50,7 @@ runs:
   using: composite
   steps:
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@ACTIONS_DOCKERLOGINACTION_VERSION
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-access-token }}
@@ -62,14 +62,14 @@ runs:
       uses: docker/setup-buildx-action@v3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ACTIONS_CONFIGUREAWSCREDENTIALS_VERSION
       with:
         role-to-assume: ${{ inputs.aws-github-role }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@ACTIONS_AMAZONECRLOGIN_VERSION
 
     # https://github.com/docker/build-push-action
     - name: Build

--- a/contract-requiring-verification-published-ecr/action.yml
+++ b/contract-requiring-verification-published-ecr/action.yml
@@ -37,17 +37,17 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ACTIONS_CONFIGUREAWSCREDENTIALS_VERSION
       with:
         role-to-assume: ${{ inputs.aws-github-role }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@ACTIONS_AMAZONECRLOGIN_VERSION
 
     - name: Login to Dockerhub
-      uses: docker/login-action@v3
+      uses: docker/login-action@ACTIONS_DOCKERLOGINACTION_VERSION
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-access-token }}
@@ -82,7 +82,7 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > pact_verification_logs.txt
 
     - name: Archive the Docker Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ACTIONS_UPLOADARTIFACT_VERSION
       if: always()
       with:
         name: pact_verification_logs

--- a/create-sdk/action.yml
+++ b/create-sdk/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: (SDK) Download Swagger File
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@ACTIONS_DOWNLOADARTIFACT_VERSION
       with:
         name: swagger-file
         path: test/tests/bin/results/updates

--- a/functional-tests-ecr/action.yml
+++ b/functional-tests-ecr/action.yml
@@ -44,17 +44,17 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ACTIONS_CONFIGUREAWSCREDENTIALS_VERSION
       with:
         role-to-assume: ${{ inputs.aws-github-role }}
         aws-region: ${{ inputs.aws-region }}
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@ACTIONS_AMAZONECRLOGIN_VERSION
 
     - name: Login to Dockerhub
-      uses: docker/login-action@v2
+      uses: docker/login-action@ACTIONS_DOCKERLOGINACTION_VERSION
       with:
         username: ${{ inputs.dockerhub-username }}
         password: ${{ inputs.dockerhub-access-token }}
@@ -64,7 +64,7 @@ runs:
       run: sudo rm -rf ./test/tests/bin
       
     - name: Download pact from this build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@ACTIONS_DOWNLOADARTIFACT_VERSION
       if: ${{ inputs.pacts-path }}
       with:
         name: pact-file
@@ -129,7 +129,7 @@ runs:
         fi 
       
     - name: Archive swagger file
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ACTIONS_UPLOADARTIFACT_VERSION
       with:
         name: swagger-file
         path: test/tests/bin/results/swagger.json
@@ -140,7 +140,7 @@ runs:
       run: docker compose -p test_${{ github.job }} logs -t > functional_test_docker_logs.txt
 
     - name: Archive the Docker Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ACTIONS_UPLOADARTIFACT_VERSION
       if: always()
       with:
         name: functional_test_docker_logs
@@ -170,7 +170,7 @@ runs:
         reporter: jest-junit
 
     - name: Report BDD Test Results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ACTIONS_UPLOADARTIFACT_VERSION
       if: ${{ inputs.bdd-flag == 'true' }}
       with:
         name: cucumber-results

--- a/package-and-publish/action.yml
+++ b/package-and-publish/action.yml
@@ -24,17 +24,17 @@ runs:
   using: composite
   steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@ACTIONS_CHECKOUT_VERSION
       with:
         fetch-depth: 0
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@ACTIONS_SETUPDOTNET_VERSION
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
         include-prerelease: false
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@ACTIONS_CACHE_VERSION
       with:
         path: ~/.nuget/packages
         key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -32,15 +32,15 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@ACTIONS_CONFIGUREAWSCREDENTIALS_VERSION
       with:
         role-to-assume: ${{ inputs.aws-github-role }}
         aws-region: ${{ inputs.aws-region }}
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v2
+      uses: aws-actions/amazon-ecr-login@ACTIONS_AMAZONECRLOGIN_VERSION
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@ACTIONS_CHECKOUT_VERSION
       with:
         fetch-depth: 1
         repository: ${{ inputs.graphql-router-repository-name }}
@@ -60,7 +60,7 @@ runs:
         cat ${{github.workspace}}/schema-latest/federate-latest.logs >> $GITHUB_STEP_SUMMARY
         echo '   ' >> $GITHUB_STEP_SUMMARY
     - name: Archive generated supergraph-latest
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ACTIONS_UPLOADARTIFACT_VERSION
       with:
         name: latest-supergraph-schema.graphql
         path: ${{github.workspace}}/schema-latest/supergraph-schema.graphql
@@ -76,7 +76,7 @@ runs:
         cat ${{github.workspace}}/schema/federate-deployed.logs
         cat ${{github.workspace}}/schema/federate-deployed.logs >> $GITHUB_STEP_SUMMARY
     - name: Archive generated supergraph-deployed
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ACTIONS_UPLOADARTIFACT_VERSION
       with:
         name: deployed-supergraph-schema.graphql
         path: ${{github.workspace}}/schema/supergraph-schema.graphql

--- a/validate-graphql/action.yml
+++ b/validate-graphql/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@ACTIONS_CHECKOUT_VERSION
       with:
         fetch-depth: 0
     - uses: kamilkisiela/graphql-inspector@release-1701263349990

--- a/validate-manifests/action.yml
+++ b/validate-manifests/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@ACTIONS_CHECKOUT_VERSION
     - uses: yokawasa/action-setup-kube-tools@v0.11.0
       with:
         setup-tools: |


### PR DESCRIPTION
Checklist
---
- [x] Unit tests are added/updated
- [x] Functional tests are added/updated
- [x] All deployment artifacts and config properties for Development and Production environments are updated
- [x] Any new or updated tooling, scripts, modules, prerequisites are updated in the readme

Motivation
---
I want to update every repo to use the new argo-deploy action params.


Modifications
---
* I added the new params in the github workflow.

Results
---
:rocket:
