### PR TITLE
(PRODEV-7834) GraphQL inspector blows up on merge queue

### DIFF
--- a/validate-graphql/action.yml
+++ b/validate-graphql/action.yml
@@ -15,6 +15,7 @@ runs:
       with:
         fetch-depth: 0
     - uses: kamilkisiela/graphql-inspector@release-1701263349990
+      if: github.event_name == 'pull-request' # Only on PR
       with:
         name: Inspect and Validate GraphQL
         schema: "main:${{inputs.path-to-graphql-schema}}"


### PR DESCRIPTION
Motivation
---
GraphQL inspector blows up on merge queue

Modifications
---
Add conditional to validate graphql action so it can only ever run on PR.

Results
---
🚀 