### PR TITLE
(PRODEV-8029) Always Report Functional Test Outputs

### DIFF
--- a/functional-tests-ecr/action.yml
+++ b/functional-tests-ecr/action.yml
@@ -155,7 +155,7 @@ runs:
 
     - name: Report BDD Functional Test Results
       uses: dorny/test-reporter@v1
-      if: ${{ inputs.bdd-flag == 'true' }}
+      if: always() && ${{ inputs.bdd-flag == 'true' }}
       with:
         name: Functional BDD Tests
         path: test/tests/bin/results/bdd/*.xml
@@ -171,14 +171,14 @@ runs:
 
     - name: Report BDD Test Results
       uses: actions/upload-artifact@v4
-      if: ${{ inputs.bdd-flag == 'true' }}
+      if: always() && ${{ inputs.bdd-flag == 'true' }}
       with:
         name: cucumber-results
         path: test/tests/bin/results/cucumber-report.html
 
     - name: Report Pact Provider Results
       uses: dorny/test-reporter@v1
-      if: ${{ inputs.pact-provider-verification }}
+      if: always() && ${{ inputs.pact-provider-verification }}
       with:
         name: Pact Provider Verification
         path: test/tests/bin/pact/*.xml

--- a/functional-tests-ecr/action.yml
+++ b/functional-tests-ecr/action.yml
@@ -155,7 +155,7 @@ runs:
 
     - name: Report BDD Functional Test Results
       uses: dorny/test-reporter@v1
-      if: always() && ${{ inputs.bdd-flag == 'true' }}
+      if: ${{ always() && inputs.bdd-flag == 'true' }}
       with:
         name: Functional BDD Tests
         path: test/tests/bin/results/bdd/*.xml
@@ -171,14 +171,14 @@ runs:
 
     - name: Report BDD Test Results
       uses: actions/upload-artifact@v4
-      if: always() && ${{ inputs.bdd-flag == 'true' }}
+      if: ${{ always() && inputs.bdd-flag == 'true' }}
       with:
         name: cucumber-results
         path: test/tests/bin/results/cucumber-report.html
 
     - name: Report Pact Provider Results
       uses: dorny/test-reporter@v1
-      if: always() && ${{ inputs.pact-provider-verification }}
+      if:  ${{ always() && inputs.pact-provider-verification }}
       with:
         name: Pact Provider Verification
         path: test/tests/bin/pact/*.xml


### PR DESCRIPTION
Motivation
---
Currently, if your functional tests fail in CI you do not get the BDD or Pact Verification results reported in your action. Example here: https://github.com/tesourohq/Tesouro.Payments.Service.BillingAccounting/actions/runs/9271738881/job/25512846844

<img width="179" alt="image" src="https://github.com/tesourohq/Tesouro-Github-Actions/assets/121881821/c1c014aa-56e1-43c9-a3af-89b6eb5a6a09">

In this specific example, the BDD tests failed, but I was only able to verify that by downloading the docker logs and looking. We need to add the `always()` parameter to make sure a step is always executed. https://docs.github.com/en/actions/learn-github-actions/expressions#always

Modifications
---
* Add `always()` to functional test reporter steps

Results
---
We can see why tests failed in CI!