### PR TITLE
(PRODEV-8122) Fix federation validation exit status check

### DIFF
--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -82,6 +82,6 @@ runs:
         path: ${{github.workspace}}/schema/supergraph-schema.graphql
     - name: Exit status check
       shell: bash
+      if: contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation') == 0
       run: |
-        if [ $(contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation')) ]; then exit 0; fi
         if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi

--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -82,6 +82,6 @@ runs:
         path: ${{github.workspace}}/schema/supergraph-schema.graphql
     - name: Exit status check
       shell: bash
-      if: ${{ ! contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation') }}
+      if: ${{ ! contains(github.event.pull_request.labels.*.name, 'expected-breaking-federation-validation') }}
       run: |
         if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi

--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -83,4 +83,5 @@ runs:
     - name: Exit status check
       shell: bash
       run: |
+        if [ contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation') ]; then exit 0; fi
         if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi

--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -80,3 +80,7 @@ runs:
       with:
         name: deployed-supergraph-schema.graphql
         path: ${{github.workspace}}/schema/supergraph-schema.graphql
+    - name: Exit status check
+      shell: bash
+      run: |
+        if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi

--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -83,5 +83,5 @@ runs:
     - name: Exit status check
       shell: bash
       run: |
-        if [ contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation') ]; then exit 0; fi
+        if [ $(contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation')) ]; then exit 0; fi
         if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi

--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -82,6 +82,6 @@ runs:
         path: ${{github.workspace}}/schema/supergraph-schema.graphql
     - name: Exit status check
       shell: bash
-      if: contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation') == 0
+      if: ${{ ! contains(github.event.issue.labels.*.name, 'expected-breaking-federation-validation') }}
       run: |
         if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi


### PR DESCRIPTION
Motivation
---
Exit with failure when rover fails to generate a supergraph.

Modifications
---
Explicitly run a status check against the docker exit codes of our rover builds.

Allow bypass with expected-breaking-federation-validation label.

Results
---
🚀 