### PR TITLE
(PRODEV-8134) Federation Validation merge group label bypass fix

### DIFF
--- a/validate-federation/action.yml
+++ b/validate-federation/action.yml
@@ -82,6 +82,6 @@ runs:
         path: ${{github.workspace}}/schema/supergraph-schema.graphql
     - name: Exit status check
       shell: bash
-      if: ${{ ! contains(github.event.pull_request.labels.*.name, 'expected-breaking-federation-validation') }}
+      if: ${{ ! contains(github.event.pull_request.labels.*.name, 'expected-breaking-federation-validation') || ! contains(github.event.merge_group.labels.*.name, 'expected-breaking-federation-validation') }}
       run: |
         if [ $(docker wait deployed) == 1 ] || [ $(docker wait latest) == 1 ]; then exit 1; fi


### PR DESCRIPTION
Motivation
---
The bypass built into the Validate Federation action isn't functioning on merge.

Modifications
---
Also conditionally validate if the merge_group event has the requisite label for bypass.

Results
---
🚀 