### PR TITLE
(PRODEV-8363) Add Jobs Image is a Environment Variable for Pact Verification

### DIFF
--- a/contract-requiring-verification-published-ecr/action.yml
+++ b/contract-requiring-verification-published-ecr/action.yml
@@ -33,6 +33,9 @@ inputs:
   aws-repository-name:
     description: AWS ECR repository name.
     required: true
+  jobs-image:
+    description: Image for the jobs container for the service.
+    required: false
 runs:
   using: composite
   steps:
@@ -64,6 +67,7 @@ runs:
         GIT_BRANCH: ${{ github.ref_name }}
         PACT_URL: ${{ inputs.pact-url }}
         GH_PACKAGES_TOKEN: ${{ inputs.gh-packages-token }}
+        JOBS_IMAGE: ${{ inputs.jobs-image }}
       shell: bash
       run: |
         # Build pact verification container and associated services


### PR DESCRIPTION
Motivation
---
Pact Verification ran through the webhook is currently failing in BillingAccounting: https://github.com/tesourohq/Tesouro.Payments.Service.BillingAccounting/actions/runs/9507438138/job/26206888987#step:6:1

This is due to the `JOBS_IMAGE` environment variable not being set:
```
  env:
    AWS_DEFAULT_REGION: us-east-1
    AWS_REGION: us-east-1
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
    AWS_SESSION_TOKEN: ***
    UNDERTEST_IMAGE: 833624450745.dkr.ecr.us-east-1.amazonaws.com/tesouro/tesouro-service-billingaccounting:latest
    PACT_BROKER_TOKEN: ***
    PROVIDER_APP_VERSION: 0.1.398
    GIT_BRANCH: main
    PACT_URL: https://tesouro.pactflow.io/pacts/provider/billingaccounting_service/consumer/reporting_service/pact-version/92fbe3e016ac7a132a1a02a1c60dafc4bd9e992a/metadata/Y3ZuPTAuMS40Ny1wci0wNDAzLjMwNyZ3PXRydWU
    GH_PACKAGES_TOKEN: ***
```

Modifications
---
* Add the jobs image as a non-required input for the action

Results
---
Pact verification will pass in BillingAccounting