### PR TITLE
(PRODEV-8462) - add step to install docker-compose

### DIFF
--- a/functional-tests-ecr/action.yml
+++ b/functional-tests-ecr/action.yml
@@ -43,6 +43,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install Docker Compose
+      shell: bash
+      run: |
+        sudo curl -L "https://github.com/docker/compose/releases/download/v2.28.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        sudo chmod +x /usr/local/bin/docker-compose
+      
     - name: Configure AWS credentials
       uses: tesourohq/Tesouro-Github-Actions/common-actions/configure-aws-credentials@main
       with:


### PR DESCRIPTION
Motivation
---
In prep for our move to Github runners in place of BuildJet, we need to have docker-compose installed at the outset of the functional tests.

Modifications
---
I added a step to pull and chmod the docker-compose binary to the runner.

Results
---
functional tests should continue uninterrupted when we switch over to Github runners.